### PR TITLE
Remove old registration system from connect.settings

### DIFF
--- a/connect/models/settings.py
+++ b/connect/models/settings.py
@@ -5,12 +5,9 @@ import os
 import re
 import string
 import random
-import uuid
-from urllib.parse import urljoin
 
 import httpx
 import openai
-import requests
 from odoo import fields, models, api, release
 from odoo.exceptions import ValidationError, UserError
 
@@ -20,7 +17,6 @@ ODUIST_MODULES.append('connect')
 
 logger = logging.getLogger(__name__)
 
-MODULE_NAME = "connect"
 MAX_EXTEN_LEN = 4
 PROTECTED_FIELDS = [
     "display_openai_api_key",
@@ -103,111 +99,19 @@ class Settings(models.Model):
     instance_uid = fields.Char("Instance UID", compute="_get_instance_data")
     api_url = fields.Char("API URL", compute="_get_instance_data")
     api_fallback_url = fields.Char("API Fallback URL")
-    customer_code = fields.Char()
-    registration_number = fields.Char(compute="_get_instance_data")
-    registration_key = fields.Char("API Key", compute="_get_instance_data")
-    is_registered = fields.Boolean()
-    i_agree_to_register = fields.Boolean()
-    i_agree_to_contact = fields.Boolean()
-    i_agree_to_receive = fields.Boolean()
-    installation_date = fields.Datetime(compute="_get_instance_data")
-    module_version = fields.Char(compute="_get_instance_data")
-    odoo_version = fields.Char(compute="_get_instance_data")
-    admin_name = fields.Char()
-    admin_phone = fields.Char(
-        help='It is required to contact this instance\'s administrator in case any critical vulnerabilities are found in the application.')
-    admin_email = fields.Char(
-        help='It is required to contact this instance administrator by email in case any non-critical vulnerabilities are found in the application.')
-    company_name = fields.Char(help='Company name of this instance.')
-    company_country = fields.Many2one('res.country',
-                                      help='We use the company\'s country information for statistical tracking of our product installations by country.')
     web_base_url = fields.Char(compute="_get_instance_data", string="Odoo URL")
     call_duration_limit = fields.Integer(compute="_get_instance_data", string="Call Duration Limit (seconds)")
-    latest_versions = fields.Html(readonly=True)
-
-    def get_module_version(self, module_name):
-        module = (
-            self.env["ir.module.module"].sudo().search([("name", "=", module_name)])
-        )
-        module_version = (
-            re.sub(r"^(\d+\.\d+\.)", "", module.installed_version) if module else ""
-        )
-        return module_version
-
-    @staticmethod
-    def get_module_list():
-        return ["connect"]
-
-    def check_latest_versions(self):
-        module_list = self.get_module_list()
-        request_data = {
-            "instance_uid": self.get_param("instance_uid"),
-            "odoo_version": release.major_version,
-            "module_list": module_list,
-        }
-        response = self.make_usage_request(
-            "check_versions", requests.post, data=request_data, raise_on_error=True
-        )
-        data = []
-        for module in module_list:
-            current_version = self.get_module_version(module)
-            latest_version = response.get(module, "")
-            data.append(
-                {
-                    "name": module,
-                    "current_version": current_version,
-                    "latest_version": latest_version,
-                }
-            )
-
-        html = self.env["ir.ui.view"]._render_template(
-            "connect.module_version_template", {"data": data}
-        )
-        self.set_param("latest_versions", html)
-
-    def set_default_admin_and_company(self):
-        self.company_name = self.env.user.company_id.name
-        self.company_country = self.env.user.company_id.country_id
-        self.admin_name = self.env.user.partner_id.name
-        self.admin_email = self.env.user.partner_id.email
-        self.admin_phone = self.env.user.partner_id.phone
-
-    def read(self, fields_to_read, load='_classic_read'):
-        if not self.admin_name:
-            self.set_default_admin_and_company()
-        res = super(Settings, self).read(fields_to_read, load=load)
-        return res
 
     def _get_instance_data(self):
-        module = (
-            self.env["ir.module.module"].sudo().search([("name", "=", MODULE_NAME)])
-        )
         for rec in self:
-            rec.module_version = re.sub(r"^(\d+\.\d+\.)", "", module.installed_version)
-            rec.odoo_version = release.major_version
             rec.instance_uid = (
                 self.env["ir.config_parameter"].sudo().get_param("connect.instance_uid")
-            )
-            rec.installation_date = (
-                self.env["ir.config_parameter"]
-                .sudo()
-                .get_param("connect.installation_date")
             )
             rec.api_url = (
                 self.env["ir.config_parameter"].sudo().get_param("connect.api_url")
             )
-            rec.registration_key = (
-                self.env["ir.config_parameter"]
-                .sudo()
-                .get_param("connect.registration_key")
-            )
             rec.web_base_url = (
                 self.env["ir.config_parameter"].sudo().get_param("web.base.url")
-            )
-            rec.registration_number = (
-                self.env["ir.config_parameter"]
-                .sudo()
-                .get_param("connect.registration_number")
             )
             rec.call_duration_limit = int(
                 self.env["ir.config_parameter"]
@@ -316,164 +220,6 @@ class Settings(models.Model):
         else:
             data = data[0]
         setattr(data, param, value)
-
-    @api.model
-    def set_instance_uid(self, instance_uid=False):
-        existing_uid = self.env["ir.config_parameter"].get_param("connect.instance_uid")
-        if not existing_uid:
-            if not instance_uid:
-                instance_uid = str(uuid.uuid4())
-            self.env["ir.config_parameter"].set_param(
-                "connect.instance_uid", instance_uid
-            )
-
-    def register_instance(self):
-        if not self.env.user.has_group("base.group_system"):
-            raise ValidationError("Only Odoo admin can do it!")
-        if self.get_param("is_registered"):
-            raise ValidationError("This instance is already registered!")
-        data = self.prepare_registration_data()
-        if not data.get("customer_code"):
-            raise ValidationError("Enter your customer code!")
-        required_fields = [
-            "admin_email",
-            "admin_name",
-            "admin_phone",
-            "company_name",
-            "company_country",
-            "installation_date",
-            "module_name",
-            "module_version",
-            "url",
-            "odoo_version",
-        ]
-        missing_fields = [field for field in required_fields if not data.get(field)]
-        if missing_fields:
-            raise ValidationError(
-                f"Please fill in the following fields: {', '.join([k.replace('_', ' ').capitalize() for k in missing_fields])}"
-            )
-        res = self.make_usage_request(
-            "registration", requests.post, data=data, raise_on_error=True
-        )
-        self.env["ir.config_parameter"].sudo().set_param(
-            "connect.registration_key", res.get("registration_key")
-        )
-        self.env["ir.config_parameter"].sudo().set_param(
-            "connect.registration_number", res.get("registration_number")
-        )
-        self.set_param("is_registered", True)
-        self.connect_notify("Instance registered successfully!", title="Registration")
-
-    def update_instance_registration(self):
-        if not self.env.user.has_group("base.group_system"):
-            raise ValidationError("Only Odoo admin can do it!")
-        if not self.get_param("is_registered"):
-            raise ValidationError("This instance is not registered yet! Please register first.")
-        data = self.prepare_registration_data()
-        required_fields = [
-            "admin_email",
-            "admin_name",
-            "admin_phone",
-            "company_name",
-            "company_country",
-            "installation_date",
-            "module_name",
-            "module_version",
-            "url",
-            "odoo_version",
-        ]
-        missing_fields = [field for field in required_fields if not data.get(field)]
-        if missing_fields:
-            raise ValidationError(
-                f"Please fill in the following fields: {', '.join([k.replace('_', ' ').capitalize() for k in missing_fields])}"
-            )
-        res = self.make_usage_request(
-            "update_registration", requests.post, data=data, raise_on_error=True
-        )
-        message = res.get("message", "Registration updated successfully!")
-        self.connect_notify(message, title="Registration Update")
-
-    def prepare_registration_data(self):
-        company_country = self.get_param("company_country")
-        return {
-            "instance_uid": self.get_param("instance_uid"),
-            "company_name": self.get_param("company_name"),
-            "company_country": company_country.name if company_country else False,
-            "company_country_code": company_country.code if company_country else False,
-            "company_country_name": company_country.name if company_country else False,
-            "admin_name": self.get_param("admin_name"),
-            "admin_email": self.get_param("admin_email"),
-            "admin_phone": self.get_param("admin_phone"),
-            "module_version": self.get_param("module_version"),
-            "module_name": MODULE_NAME,
-            "odoo_version": self.get_param("odoo_version"),
-            "odoo_full_version": release.version,
-            "url": self.get_param("web_base_url"),
-            "installation_date": self.get_param("installation_date").strftime(
-                "%Y-%m-%d"
-            ),
-            "customer_code": self.get_param("customer_code"),
-        }
-
-    def get_usage_model_list(self):
-        return [
-            "call",
-            "callflow",
-            "exten",
-            "message",
-            "number",
-            "outgoing_callerid",
-            "recording",
-            "user",
-        ]
-
-    @api.model
-    def update_usage(self):
-        res = {
-            "usage": {},
-            "usage_errors": {},
-        }
-        for model in self.get_usage_model_list():
-            try:
-                res["usage"][model] = {
-                    "count": self.env["connect.{}".format(model)].search_count([]),
-                }
-                if model == "call":
-                    self.env.cr.execute("SELECT SUM(duration)/60 FROM connect_call")
-                    call_minutes = self.env.cr.fetchall()[0][0]
-                    res["usage"][model]["minutes"] = call_minutes
-            except Exception as e:
-                res["usage_errors"][model] = str(e)
-        data = self.prepare_registration_data()
-        data.update(res)
-        try:
-            self.make_usage_request("usage", requests.post, data)
-        except Exception as e:
-            logger.exception("Usage error:")
-
-    def make_usage_request(
-        self, path, method, data={}, headers={}, raise_on_error=False
-    ):
-        url = self.env["ir.config_parameter"].get_param(
-            "connect.registration_url", "https://api1.oduist.com/instance/"
-        )
-        if not url.endswith("/"):
-            url = "{}/".format(url)
-        res = None
-        try:
-            res = method(urljoin(url, path), json=data, headers=headers)
-            if res.status_code == 200:
-                res = res.json()
-                if res.get("error"):
-                    raise ValidationError(res["error"])
-                return res
-            else:
-                raise ValidationError(res.text)
-        except Exception as e:
-            if raise_on_error:
-                raise ValidationError(str(e))
-            else:
-                return {}
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/connect/models/settings.py
+++ b/connect/models/settings.py
@@ -212,7 +212,7 @@ class Settings(models.Model):
             rec.call_duration_limit = int(
                 self.env["ir.config_parameter"]
                 .sudo()
-                .get_param("connect.call_duration_limit", "240")
+                .get_param("connect.call_duration_limit", "7200")
             )
 
     @api.model

--- a/connect/views/settings.xml
+++ b/connect/views/settings.xml
@@ -34,6 +34,7 @@
                                     <field name="api_url" readonly="1"/>
                                     <field name="web_base_url" readonly="1"/>
                                     <field name="instance_uid" readonly="1"/>
+                                    <field name="call_duration_limit" readonly="1"/>
                                 </group>
                             </group>
                         </page>
@@ -50,43 +51,6 @@
                             </group>
                             <group string="Summary Prompt">
                                 <field name="summary_prompt" nolabel="1" colspan="2"/>
-                            </group>
-                        </page>
-                        <page name="registration" string="Registration">
-                            <group>
-                                <group string="Registration Info">
-                                    <field name="is_registered" readonly="1"/>
-                                    <field name="customer_code"/>
-                                    <field name="registration_number" readonly="1"/>
-                                    <field name="registration_key" readonly="1"/>
-                                </group>
-                                <group string="Admin Contact">
-                                    <field name="admin_name"/>
-                                    <field name="admin_phone"/>
-                                    <field name="admin_email"/>
-                                    <field name="company_name"/>
-                                    <field name="company_country"/>
-                                </group>
-                            </group>
-                            <group>
-                                <group>
-                                    <field name="i_agree_to_register"/>
-                                    <field name="i_agree_to_contact"/>
-                                    <field name="i_agree_to_receive"/>
-                                </group>
-                            </group>
-                        </page>
-                        <page name="system" string="System">
-                            <group>
-                                <group string="System Info">
-                                    <field name="module_version" readonly="1"/>
-                                    <field name="odoo_version" readonly="1"/>
-                                    <field name="installation_date" readonly="1"/>
-                                    <field name="call_duration_limit" readonly="1"/>
-                                </group>
-                                <group string="Version Check">
-                                    <field name="latest_versions" readonly="1" nolabel="1"/>
-                                </group>
                             </group>
                         </page>
                     </notebook>

--- a/docs/admin/core-setup.md
+++ b/docs/admin/core-setup.md
@@ -29,20 +29,6 @@ Connect uses OpenAI for automatic call transcription and summarization.
     4. The summary is saved on both the recording and the call record
     5. If enabled, the summary is posted to the partner's chatter
 
-## Registration Tab
-
-Register your Connect instance with Oduist for license management, updates, and support.
-
-| Setting | Description |
-|---------|-------------|
-| **Admin Contact** | Name, phone, email of the instance administrator. |
-| **Company Name** | Your company name and country. |
-| **License Token** | Paste a JWT license token from [oduist.com](https://oduist.com). |
-| **Subscription Preferences** | Subscribe to security alerts, onboarding support, and product news. |
-
-## System Tab (Read-only)
-
-Displays module version, Odoo version, installation date, and call duration limit.
 
 ## PBX Users
 

--- a/docs/admin/installation.md
+++ b/docs/admin/installation.md
@@ -46,6 +46,6 @@
 
 After installation, navigate to **Connect > Configuration > Settings** to configure your telephony provider. See the provider-specific setup guides:
 
-- [Core Configuration](core-setup.md) — General settings, transcription, registration
+- [Core Configuration](core-setup.md) — General settings, transcription
 - [Twilio Setup](twilio-setup.md) — Twilio account, SIP domains, WhatsApp
 - [FreeSWITCH Setup](freeswitch-setup.md) — FreeSWITCH server, gateways, endpoints

--- a/specs/connect_core.md
+++ b/specs/connect_core.md
@@ -47,23 +47,7 @@ for easy access from other models.
 | `api_url` | Char | Computed |
 | `api_fallback_url` | Char | |
 | `web_base_url` | Char | Computed |
-| `module_version` | Char | Computed |
-| `odoo_version` | Char | Computed |
-| `installation_date` | Datetime | Computed |
-| `call_duration_limit` | Integer | Computed |
-| `customer_code` | Char | |
-| `registration_number` | Char | Computed |
-| `registration_key` | Char | Computed |
-| `is_registered` | Boolean | |
-| `i_agree_to_register` | Boolean | |
-| `i_agree_to_contact` | Boolean | |
-| `i_agree_to_receive` | Boolean | |
-| `admin_name` | Char | |
-| `admin_phone` | Char | |
-| `admin_email` | Char | |
-| `company_name` | Char | |
-| `company_country` | Many2one | `res.country` |
-| `latest_versions` | Html | Readonly |
+| `call_duration_limit` | Integer | Computed from `ir.config_parameter` |
 | `openai_api_key` | Char | Groups: `base.group_erp_manager` |
 | `display_openai_api_key` | Char | Masked display field |
 
@@ -77,16 +61,9 @@ for easy access from other models.
 | `connect_notify(bus)` | Send bus notification |
 | `connect_reload_view(bus)` | Send bus reload event |
 | `set_defaults()` | Set installation defaults |
-| `set_instance_uid()` | Generate UUID for instance |
-| `register_instance()` | Register with Oduist API |
-| `update_instance_registration()` | Update registration data |
-| `prepare_registration_data()` | Build registration payload |
-| `update_usage()` | Track usage statistics |
-| `make_usage_request()` | HTTP call to usage API |
-| `check_api_url()` | Validate API URL reachability |
+| `check_api_url()` | Validate API URL format |
 | `reformat_numbers_button()` | Re-normalize partner phone numbers |
 | `action_open_system_parameters()` | UI action |
-| `check_latest_versions()` | Version check against API |
 | `get_openai_client()` | Create and return OpenAI client instance |
 
 **Notes:**

--- a/specs/decisions/007-remove-old-registration.md
+++ b/specs/decisions/007-remove-old-registration.md
@@ -1,0 +1,27 @@
+# 007 - Remove Old Registration System
+
+## Problem
+
+The `connect.settings` model contained an old registration system that communicated with `api1.oduist.com/instance/` for instance registration, usage tracking, and version checking. This has been superseded by the new `oduist.license` model and license server.
+
+## Options Considered
+
+1. **Keep both systems** — confusing for users, maintenance burden
+2. **Remove old registration** — clean break, new license system handles everything
+
+## Decision
+
+Remove all old registration fields, methods, and UI (Registration tab, System tab) from `connect.settings`. The new `oduist.license` model handles licensing, registration numbers, and instance identification.
+
+## What Was Removed
+
+- **Fields:** `customer_code`, `registration_number`, `registration_key`, `is_registered`, `i_agree_to_*`, `admin_name`, `admin_phone`, `admin_email`, `company_name`, `company_country`, `installation_date`, `module_version`, `odoo_version`, `latest_versions`
+- **Methods:** `register_instance()`, `update_instance_registration()`, `prepare_registration_data()`, `update_usage()`, `make_usage_request()`, `check_latest_versions()`, `get_module_version()`, `get_module_list()`, `set_default_admin_and_company()`, `set_instance_uid()`
+- **UI:** Registration tab, System tab from settings form
+
+## What Was Kept
+
+- `instance_uid`, `api_url`, `web_base_url` — used by core and integrations
+- `call_duration_limit` — used by `connect_twilio` for Twilio call `timeLimit` (moved to General tab)
+- `set_defaults()` — called from `functions.xml` during install/upgrade
+- `check_api_url()` — used by `connect_twilio`


### PR DESCRIPTION
## Summary

- Remove the old Registration and System tabs from `connect.settings` form, replacing them with the new `oduist.license` model
- Delete 15 registration-related fields, 10 methods, and all old API calls to `api1.oduist.com/instance/`
- Keep `call_duration_limit` (used by `connect_twilio`) and move it to the General tab
- Fix `call_duration_limit` default from 240 to 7200 seconds
- Update specs, docs, and add ADR `007-remove-old-registration.md`

## Test plan

- [x] Module upgrade succeeds on Odoo 19.0 (tested on oduflow)
- [x] All 16 removed fields cleaned up automatically by Odoo
- [ ] Settings form loads with only General and Transcription tabs
- [ ] `call_duration_limit` visible in General tab API group


🤖 Generated with [Claude Code](https://claude.com/claude-code)