### PR TITLE
feat: replace FreeSWITCH XML generation with Jinja2 templates

### DIFF
--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,12 +1,14 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.0.3',
+    'version': '19.0.1.1.0',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',
     'depends': ['connect', 'web'],
     'data': [
         'security/access_rules.xml',
+        'data/fs_templates.xml',
         'views/endpoint_views.xml',
+        'views/fs_template_views.xml',
         'views/gateway_views.xml',
         'views/outgoing_route_views.xml',
         'views/settings.xml',

--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.1.0',
+    'version': '19.0.1.1.1',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',
     'depends': ['connect', 'web'],

--- a/connect_freeswitch/controllers/freeswitch_xml.py
+++ b/connect_freeswitch/controllers/freeswitch_xml.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
 import re
-from xml.etree import ElementTree as ET
 from xml.dom import minidom
 
 from odoo import http
@@ -111,57 +110,38 @@ class FreeSwitchXMLController(http.Controller):
         fs_domain = request.env['connect.settings'].sudo().get_param('freeswitch_domain')
         actual_domain = fs_domain or domain or params.get('sip_auth_realm', '')
 
-        root = ET.Element('document', type='freeswitch/xml')
-        section = ET.SubElement(root, 'section', name='directory')
-        domain_el = ET.SubElement(section, 'domain', name=actual_domain)
-
-        # User ID is dynamic
-        user_el = ET.SubElement(domain_el, 'user', id=xml_user_id)
-
-        # Params
-        user_params = ET.SubElement(user_el, 'params')
-        ET.SubElement(user_params, 'param', name='password', value=endpoint.auth_password or '')
-        ET.SubElement(user_params, 'param', name='vm-password', value=endpoint.auth_password or '')
-
         # Build dial-string so that bridge(user/1000) works
-        # This tells FS to ring both SIP and Verto endpoints for this user
-        # For sofia_contact, use auth_user (the SIP registration username)
-        # For verto_contact, use xml_user_id (the extension number used for Verto login)
         dial_parts = []
         if endpoint.sip_enabled:
-            dial_parts.append(f"${{sofia_contact(*/{endpoint.auth_user}@{actual_domain})}}")
+            dial_parts.append("${{sofia_contact(*/{auth_user}@{domain})}}".format(
+                auth_user=endpoint.auth_user, domain=actual_domain))
         if endpoint.webrtc_enabled:
-            dial_parts.append(f"${{verto_contact({xml_user_id}@{actual_domain})}}")
-
+            dial_parts.append("${{verto_contact({user_id}@{domain})}}".format(
+                user_id=xml_user_id, domain=actual_domain))
         dial_string = ",".join(dial_parts)
-        ET.SubElement(user_params, 'param', name='dial-string', value=dial_string)
 
-        # Verto-specific
-        ET.SubElement(user_params, 'param', name='verto-context', value='default')
-        ET.SubElement(user_params, 'param', name='verto-dialplan', value='XML')
-        ET.SubElement(user_params, 'param', name='jsonrpc-allowed-methods', value='verto')
-        ET.SubElement(user_params, 'param', name='jsonrpc-allowed-event-channels', value='demo,presence,conference')
-
-        # Variables
-        variables = ET.SubElement(user_el, 'variables')
-        ET.SubElement(variables, 'variable', name='user_context', value='default')
-
-        # Caller ID from the associated connect user
         cid_name = connect_user.name or endpoint.auth_user
         cid_num = connect_user.exten_number or endpoint.auth_user
 
-        ET.SubElement(variables, 'variable', name='effective_caller_id_name', value=cid_name)
-        ET.SubElement(variables, 'variable', name='effective_caller_id_number', value=cid_num)
-        ET.SubElement(variables, 'variable', name='outbound_caller_id_name', value=cid_name)
-        ET.SubElement(variables, 'variable', name='outbound_caller_id_number', value=cid_num)
+        Template = request.env['connect.freeswitch.template'].sudo()
+        user_xml = Template.render('directory_user', {
+            'xml_user_id': xml_user_id,
+            'password': endpoint.auth_password or '',
+            'dial_string': dial_string,
+            'cid_name': cid_name,
+            'cid_num': cid_num,
+            'connect_user_id': str(connect_user.id),
+            'endpoint_id': str(endpoint.id),
+            'odoo_user_id': str(connect_user.user.id) if connect_user.user else '',
+        })
 
-        # Odoo Tracking
-        ET.SubElement(variables, 'variable', name='odoo_connect_user_id', value=str(connect_user.id))
-        ET.SubElement(variables, 'variable', name='odoo_endpoint_id', value=str(endpoint.id))
-        if connect_user.user:
-            ET.SubElement(variables, 'variable', name='odoo_user_id', value=str(connect_user.user.id))
-
-        return self._xml_response(root)
+        xml_str = ('<document type="freeswitch/xml">'
+                   '<section name="directory">'
+                   '<domain name="{domain}">'
+                   '{body}'
+                   '</domain></section></document>').format(
+                       domain=actual_domain, body=user_xml)
+        return self._xml_response_str(xml_str)
 
     def _get_full_directory(self, domain):
         """Generate full directory XML with all users."""
@@ -179,38 +159,29 @@ class FreeSwitchXMLController(http.Controller):
 
         actual_domain = request.env['connect.settings'].sudo().get_param('freeswitch_domain') or domain
 
-        root = ET.Element('document', type='freeswitch/xml')
-        section = ET.SubElement(root, 'section', name='directory')
-        domain_el = ET.SubElement(section, 'domain', name=actual_domain)
-
-        # Users directly inside domain (flat structure for xml_curl compatibility)
+        ep_data = []
         for endpoint in endpoints:
             connect_user = endpoint.connect_user_id
+            ep_data.append({
+                'auth_user': endpoint.auth_user,
+                'password': endpoint.auth_password,
+                'cid_name': connect_user.name or endpoint.auth_user,
+                'cid_num': connect_user.exten_number or endpoint.auth_user,
+                'connect_user_id': str(connect_user.id),
+                'endpoint_id': str(endpoint.id),
+                'odoo_user_id': str(connect_user.user.id) if connect_user.user else '',
+            })
 
-            user_el = ET.SubElement(domain_el, 'user', id=endpoint.auth_user)
+        Template = request.env['connect.freeswitch.template'].sudo()
+        body = Template.render('directory_full', {'endpoints': ep_data})
 
-            # Params with Verto support
-            user_params = ET.SubElement(user_el, 'params')
-            ET.SubElement(user_params, 'param', name='password', value=endpoint.auth_password)
-            ET.SubElement(user_params, 'param', name='vm-password', value=endpoint.auth_password)
-            ET.SubElement(user_params, 'param', name='verto-context', value='default')
-            ET.SubElement(user_params, 'param', name='verto-dialplan', value='XML')
-            ET.SubElement(user_params, 'param', name='jsonrpc-allowed-methods', value='verto')
-            ET.SubElement(user_params, 'param', name='jsonrpc-allowed-event-channels', value='demo,presence,conference')
-
-            # Variables
-            variables = ET.SubElement(user_el, 'variables')
-            ET.SubElement(variables, 'variable', name='user_context', value='default')
-            ET.SubElement(variables, 'variable', name='effective_caller_id_name', value=connect_user.name or endpoint.auth_user)
-            ET.SubElement(variables, 'variable', name='effective_caller_id_number', value=connect_user.exten_number or endpoint.auth_user)
-            ET.SubElement(variables, 'variable', name='outbound_caller_id_name', value=connect_user.name or endpoint.auth_user)
-            ET.SubElement(variables, 'variable', name='outbound_caller_id_number', value=connect_user.exten_number or endpoint.auth_user)
-            ET.SubElement(variables, 'variable', name='odoo_connect_user_id', value=str(connect_user.id))
-            ET.SubElement(variables, 'variable', name='odoo_endpoint_id', value=str(endpoint.id))
-            if connect_user.user:
-                ET.SubElement(variables, 'variable', name='odoo_user_id', value=str(connect_user.user.id))
-
-        return self._xml_response(root)
+        xml_str = ('<document type="freeswitch/xml">'
+                   '<section name="directory">'
+                   '<domain name="{domain}">'
+                   '{body}'
+                   '</domain></section></document>').format(
+                       domain=actual_domain, body=body)
+        return self._xml_response_str(xml_str)
 
     def _handle_dialplan(self, params):
         """Handle dialplan section requests.
@@ -224,20 +195,20 @@ class FreeSwitchXMLController(http.Controller):
 
         debug(request.env['connect.settings'].sudo(), "Dialplan request: context=%s, destination=%s" % (context, destination))
 
-        root = ET.Element('document', type='freeswitch/xml')
-        section = ET.SubElement(root, 'section', name='dialplan')
-        context_el = ET.SubElement(section, 'context', name=context)
-
         if context == 'public':
-            # Inbound DID routing
-            self._route_inbound(context_el, destination, params)
+            body = self._route_inbound(destination, params)
         else:
-            # Internal routing: extensions, outgoing, system
-            self._route_internal(context_el, destination, params)
+            body = self._route_internal(destination, params)
 
-        return self._xml_response(root)
+        xml_str = ('<document type="freeswitch/xml">'
+                   '<section name="dialplan">'
+                   '<context name="{context}">'
+                   '{body}'
+                   '</context></section></document>').format(
+                       context=context, body=body)
+        return self._xml_response_str(xml_str)
 
-    def _route_inbound(self, context_el, destination, params):
+    def _route_inbound(self, destination, params):
         """Route inbound calls from PSTN trunks via connect.number."""
         Number = request.env['connect.number'].sudo()
 
@@ -253,27 +224,30 @@ class FreeSwitchXMLController(http.Controller):
             ], limit=1)
 
         if number:
-            number.generate_dialplan(context_el, params)
-        else:
-            _logger.warning("No DID configured for inbound number: %s", destination)
-            ext = ET.SubElement(context_el, 'extension', name='unmatched_inbound')
-            condition = ET.SubElement(ext, 'condition',
-                field='destination_number', expression='.*')
-            ET.SubElement(condition, 'action', application='respond', data='404')
+            return number.generate_dialplan(params)
 
-    def _route_internal(self, context_el, destination, params):
+        _logger.warning("No DID configured for inbound number: %s", destination)
+        return ('<extension name="unmatched_inbound">'
+                '<condition field="destination_number" expression=".*">'
+                '<action application="respond" data="404"/>'
+                '</condition></extension>')
+
+    def _route_internal(self, destination, params):
         """Route internal calls: extensions, outgoing routes, system extensions."""
         Exten = request.env['connect.exten'].sudo()
         ConnectUser = request.env['connect.user'].sudo()
 
+        parts = []
+
         # System extensions
-        self._add_system_extensions(context_el)
+        Template = request.env['connect.freeswitch.template'].sudo()
+        parts.append(Template.render('dialplan_system', {}))
 
         # Try exact extension match
         exten = Exten.search([('number', '=', destination)], limit=1)
         if exten:
-            exten.generate_dialplan(context_el, params)
-            return
+            parts.append(exten.generate_dialplan(params))
+            return ''.join(parts)
 
         # Try user by username (handles transfers that use username instead of extension)
         connect_user = ConnectUser.search([
@@ -281,41 +255,38 @@ class FreeSwitchXMLController(http.Controller):
             ('active', '=', True)
         ], limit=1)
         if connect_user:
-            connect_user.generate_dialplan(context_el, params)
-            return
+            parts.append(connect_user.generate_dialplan(params))
+            return ''.join(parts)
 
         # Try regex pattern match against all extensions
         all_extens = Exten.search([])
         for ext in all_extens:
             try:
                 if re.match('^{}$'.format(ext.number), destination):
-                    ext.generate_dialplan(context_el, params)
-                    return
+                    parts.append(ext.generate_dialplan(params))
+                    return ''.join(parts)
             except re.error:
                 continue
 
         # Try outgoing routes
         OutgoingRoute = request.env['connect.freeswitch.outgoing_route'].sudo()
-        if OutgoingRoute.generate_dialplan(context_el, params):
-            return
+        route_xml = OutgoingRoute.generate_dialplan(params)
+        if route_xml:
+            parts.append(route_xml)
+            return ''.join(parts)
 
         # Fallback: try bridge user directly (for simple digit-only extensions)
         if re.match(r'^\d+$', destination):
-            ext = ET.SubElement(context_el, 'extension', name='local_extension')
-            condition = ET.SubElement(ext, 'condition',
-                field='destination_number', expression=r'^(\d+)$')
-            ET.SubElement(condition, 'action', application='set', data='call_timeout=30')
-            ET.SubElement(condition, 'action', application='set', data='hangup_after_bridge=true')
-            ET.SubElement(condition, 'action', application='set', data='continue_on_fail=true')
-            ET.SubElement(condition, 'action', application='bridge', data='user/$1@$${domain}')
+            parts.append(
+                '<extension name="local_extension">'
+                '<condition field="destination_number" expression="^(\\d+)$">'
+                '<action application="set" data="call_timeout=30"/>'
+                '<action application="set" data="hangup_after_bridge=true"/>'
+                '<action application="set" data="continue_on_fail=true"/>'
+                '<action application="bridge" data="user/$1@$${domain}"/>'
+                '</condition></extension>')
 
-    def _add_system_extensions(self, context_el):
-        """Add system utility extensions (echo test, etc.)."""
-        echo_ext = ET.SubElement(context_el, 'extension', name='echo')
-        echo_cond = ET.SubElement(echo_ext, 'condition',
-            field='destination_number', expression='^9196$')
-        ET.SubElement(echo_cond, 'action', application='answer')
-        ET.SubElement(echo_cond, 'action', application='echo')
+        return ''.join(parts)
 
     def _handle_configuration(self, params):
         """Handle configuration section requests.
@@ -340,50 +311,31 @@ class FreeSwitchXMLController(http.Controller):
         return self._not_found()
 
     def _get_sofia_config(self, params):
-        """Serve sofia.conf with gateways from Odoo.
-
-        Returns a sofia configuration containing an external profile
-        with all active gateways defined in Odoo. If no gateways exist,
-        falls through to local config.
-        """
+        """Serve sofia.conf with gateways from Odoo."""
         Gateway = request.env['connect.freeswitch.gateway'].sudo()
         gateways = Gateway.search([('active', '=', True)])
 
         if not gateways:
             return self._not_found()
 
-        root = ET.Element('document', type='freeswitch/xml')
-        section = ET.SubElement(root, 'section', name='configuration')
-        config = ET.SubElement(section, 'configuration',
-            name='sofia.conf', description='Sofia SIP')
+        # Render each gateway individually
+        gateways_xml = '\n'.join(gw.generate_sofia_gateway_xml() for gw in gateways)
 
-        # Global settings
-        global_settings = ET.SubElement(config, 'global_settings')
         sofia_log_level = request.env['connect.settings'].sudo().get_param('freeswitch_sofia_log_level') or '0'
-        ET.SubElement(global_settings, 'param', name='log-level', value=sofia_log_level)
-
-        profiles = ET.SubElement(config, 'profiles')
-
-        # External profile for gateways
-        profile = ET.SubElement(profiles, 'profile', name='external')
-        settings = ET.SubElement(profile, 'settings')
-        ET.SubElement(settings, 'param', name='context', value='public')
-        ET.SubElement(settings, 'param', name='sip-port', value='5080')
-        ET.SubElement(settings, 'param', name='rtp-timer-name', value='soft')
-        ET.SubElement(settings, 'param', name='codec-prefs', value='OPUS,PCMU,PCMA')
-        ET.SubElement(settings, 'param', name='auth-calls', value='true')
-
         fs_domain = request.env['connect.settings'].sudo().get_param('freeswitch_domain')
-        if fs_domain:
-            ET.SubElement(settings, 'param', name='force-register-domain', value=fs_domain)
-            ET.SubElement(settings, 'param', name='force-realm', value=fs_domain)
-            ET.SubElement(settings, 'param', name='force-register-db-domain', value=fs_domain)
 
-        gateways_el = ET.SubElement(profile, 'gateways')
-        for gw in gateways:
-            gw.generate_sofia_gateway_xml(gateways_el)
+        Template = request.env['connect.freeswitch.template'].sudo()
+        config_xml = Template.render('config_sofia', {
+            'sofia_log_level': sofia_log_level,
+            'fs_domain': fs_domain or '',
+            'gateways_xml': gateways_xml,
+        })
 
-        return self._xml_response(root)
+        xml_str = ('<document type="freeswitch/xml">'
+                   '<section name="configuration">'
+                   '{body}'
+                   '</section></document>').format(body=config_xml)
+        return self._xml_response_str(xml_str)
 
     def _get_xml_rpc_config(self, params):
         """Serve xml_rpc.conf with credentials from Odoo settings."""
@@ -396,23 +348,21 @@ class FreeSwitchXMLController(http.Controller):
 
         port = str(settings.get_param('freeswitch_xmlrpc_port') or 8080)
 
-        root = ET.Element('document', type='freeswitch/xml')
-        section = ET.SubElement(root, 'section', name='configuration')
-        config = ET.SubElement(section, 'configuration',
-            name='xml_rpc.conf', description='XML RPC')
+        Template = request.env['connect.freeswitch.template'].sudo()
+        config_xml = Template.render('config_xml_rpc', {
+            'port': port,
+            'user': user,
+            'password': password,
+        })
 
-        settings_el = ET.SubElement(config, 'settings')
-        ET.SubElement(settings_el, 'param', name='http-port', value=port)
-        ET.SubElement(settings_el, 'param', name='auth-user', value=user)
-        ET.SubElement(settings_el, 'param', name='auth-pass', value=password)
-        ET.SubElement(settings_el, 'param', name='auth-realm', value='freeswitch')
+        xml_str = ('<document type="freeswitch/xml">'
+                   '<section name="configuration">'
+                   '{body}'
+                   '</section></document>').format(body=config_xml)
+        return self._xml_response_str(xml_str)
 
-        return self._xml_response(root)
-
-    def _xml_response(self, root):
-        """Generate HTTP response with XML content."""
-        xml_str = ET.tostring(root, encoding='unicode', method='xml')
-
+    def _xml_response_str(self, xml_str):
+        """Generate HTTP response from an XML string."""
         # Pretty-print XML for logging
         pretty = pretty_xml(xml_str)
         debug(request.env['connect.settings'].sudo(), "XML response:\n%s" % pretty)
@@ -425,7 +375,8 @@ class FreeSwitchXMLController(http.Controller):
 
     def _not_found(self):
         """Return not found response."""
-        root = ET.Element('document', type='freeswitch/xml')
-        section = ET.SubElement(root, 'section', name='result')
-        ET.SubElement(section, 'result', status='not found')
-        return self._xml_response(root)
+        xml_str = ('<document type="freeswitch/xml">'
+                   '<section name="result">'
+                   '<result status="not found"/>'
+                   '</section></document>')
+        return self._xml_response_str(xml_str)

--- a/connect_freeswitch/data/fs_templates.xml
+++ b/connect_freeswitch/data/fs_templates.xml
@@ -1,0 +1,532 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <!-- ==================== DIRECTORY TEMPLATES ==================== -->
+
+    <record id="fs_template_directory_user" model="connect.freeswitch.template">
+        <field name="key">directory_user</field>
+        <field name="name">Directory - Single User</field>
+        <field name="section">directory</field>
+        <field name="description">Single user directory entry for authentication and endpoint lookup.
+
+Variables:
+  xml_user_id    - User ID as requested by FreeSWITCH
+  password       - Endpoint auth password
+  dial_string    - Combined SIP/Verto dial string
+  cid_name       - Caller ID name
+  cid_num        - Caller ID number
+  connect_user_id - connect.user record ID
+  endpoint_id    - connect.endpoint record ID
+  odoo_user_id   - res.users record ID (may be empty)</field>
+        <field name="content"><![CDATA[<user id="{{ xml_user_id }}">
+  <params>
+    <param name="password" value="{{ password }}"/>
+    <param name="vm-password" value="{{ password }}"/>
+    <param name="dial-string" value="{{ dial_string }}"/>
+    <param name="verto-context" value="default"/>
+    <param name="verto-dialplan" value="XML"/>
+    <param name="jsonrpc-allowed-methods" value="verto"/>
+    <param name="jsonrpc-allowed-event-channels" value="demo,presence,conference"/>
+  </params>
+  <variables>
+    <variable name="user_context" value="default"/>
+    <variable name="effective_caller_id_name" value="{{ cid_name }}"/>
+    <variable name="effective_caller_id_number" value="{{ cid_num }}"/>
+    <variable name="outbound_caller_id_name" value="{{ cid_name }}"/>
+    <variable name="outbound_caller_id_number" value="{{ cid_num }}"/>
+    <variable name="odoo_connect_user_id" value="{{ connect_user_id }}"/>
+    <variable name="odoo_endpoint_id" value="{{ endpoint_id }}"/>
+    {% if odoo_user_id %}
+    <variable name="odoo_user_id" value="{{ odoo_user_id }}"/>
+    {% endif %}
+  </variables>
+</user>]]></field>
+        <field name="default_content"><![CDATA[<user id="{{ xml_user_id }}">
+  <params>
+    <param name="password" value="{{ password }}"/>
+    <param name="vm-password" value="{{ password }}"/>
+    <param name="dial-string" value="{{ dial_string }}"/>
+    <param name="verto-context" value="default"/>
+    <param name="verto-dialplan" value="XML"/>
+    <param name="jsonrpc-allowed-methods" value="verto"/>
+    <param name="jsonrpc-allowed-event-channels" value="demo,presence,conference"/>
+  </params>
+  <variables>
+    <variable name="user_context" value="default"/>
+    <variable name="effective_caller_id_name" value="{{ cid_name }}"/>
+    <variable name="effective_caller_id_number" value="{{ cid_num }}"/>
+    <variable name="outbound_caller_id_name" value="{{ cid_name }}"/>
+    <variable name="outbound_caller_id_number" value="{{ cid_num }}"/>
+    <variable name="odoo_connect_user_id" value="{{ connect_user_id }}"/>
+    <variable name="odoo_endpoint_id" value="{{ endpoint_id }}"/>
+    {% if odoo_user_id %}
+    <variable name="odoo_user_id" value="{{ odoo_user_id }}"/>
+    {% endif %}
+  </variables>
+</user>]]></field>
+    </record>
+
+    <record id="fs_template_directory_full" model="connect.freeswitch.template">
+        <field name="key">directory_full</field>
+        <field name="name">Directory - Full</field>
+        <field name="section">directory</field>
+        <field name="description">Full directory with all active endpoints. Used for bulk registration requests.
+
+Variables:
+  endpoints - List of dicts, each with:
+    auth_user        - SIP registration username
+    password         - Auth password
+    cid_name         - Caller ID name
+    cid_num          - Caller ID number
+    connect_user_id  - connect.user record ID
+    endpoint_id      - connect.endpoint record ID
+    odoo_user_id     - res.users record ID (may be empty)</field>
+        <field name="content"><![CDATA[{% for ep in endpoints %}
+<user id="{{ ep.auth_user }}">
+  <params>
+    <param name="password" value="{{ ep.password }}"/>
+    <param name="vm-password" value="{{ ep.password }}"/>
+    <param name="verto-context" value="default"/>
+    <param name="verto-dialplan" value="XML"/>
+    <param name="jsonrpc-allowed-methods" value="verto"/>
+    <param name="jsonrpc-allowed-event-channels" value="demo,presence,conference"/>
+  </params>
+  <variables>
+    <variable name="user_context" value="default"/>
+    <variable name="effective_caller_id_name" value="{{ ep.cid_name }}"/>
+    <variable name="effective_caller_id_number" value="{{ ep.cid_num }}"/>
+    <variable name="outbound_caller_id_name" value="{{ ep.cid_name }}"/>
+    <variable name="outbound_caller_id_number" value="{{ ep.cid_num }}"/>
+    <variable name="odoo_connect_user_id" value="{{ ep.connect_user_id }}"/>
+    <variable name="odoo_endpoint_id" value="{{ ep.endpoint_id }}"/>
+    {% if ep.odoo_user_id %}
+    <variable name="odoo_user_id" value="{{ ep.odoo_user_id }}"/>
+    {% endif %}
+  </variables>
+</user>
+{% endfor %}]]></field>
+        <field name="default_content"><![CDATA[{% for ep in endpoints %}
+<user id="{{ ep.auth_user }}">
+  <params>
+    <param name="password" value="{{ ep.password }}"/>
+    <param name="vm-password" value="{{ ep.password }}"/>
+    <param name="verto-context" value="default"/>
+    <param name="verto-dialplan" value="XML"/>
+    <param name="jsonrpc-allowed-methods" value="verto"/>
+    <param name="jsonrpc-allowed-event-channels" value="demo,presence,conference"/>
+  </params>
+  <variables>
+    <variable name="user_context" value="default"/>
+    <variable name="effective_caller_id_name" value="{{ ep.cid_name }}"/>
+    <variable name="effective_caller_id_number" value="{{ ep.cid_num }}"/>
+    <variable name="outbound_caller_id_name" value="{{ ep.cid_name }}"/>
+    <variable name="outbound_caller_id_number" value="{{ ep.cid_num }}"/>
+    <variable name="odoo_connect_user_id" value="{{ ep.connect_user_id }}"/>
+    <variable name="odoo_endpoint_id" value="{{ ep.endpoint_id }}"/>
+    {% if ep.odoo_user_id %}
+    <variable name="odoo_user_id" value="{{ ep.odoo_user_id }}"/>
+    {% endif %}
+  </variables>
+</user>
+{% endfor %}]]></field>
+    </record>
+
+    <!-- ==================== DIALPLAN TEMPLATES ==================== -->
+
+    <record id="fs_template_dialplan_user_bridge" model="connect.freeswitch.template">
+        <field name="key">dialplan_user_bridge</field>
+        <field name="name">Dialplan - User Bridge</field>
+        <field name="section">dialplan</field>
+        <field name="description">Bridge a call to a user's SIP/WebRTC endpoints.
+
+Variables:
+  number          - Extension number (escaped for regex)
+  user_id         - connect.user record ID
+  exten_id        - connect.exten record ID (may be empty)
+  record_calls    - Boolean, whether to record the call
+  recording_url   - URL for recording webhook (if record_calls)
+  fs_domain       - FreeSWITCH SIP domain</field>
+        <field name="content"><![CDATA[<extension name="user_{{ number }}">
+  <condition field="destination_number" expression="^{{ number }}$">
+    <action application="set" data="odoo_called_user_id={{ user_id }}"/>
+    {% if exten_id %}
+    <action application="set" data="odoo_exten_id={{ exten_id }}"/>
+    {% endif %}
+    {% if record_calls and recording_url %}
+    <action application="set" data="RECORD_STEREO=true"/>
+    <action application="set" data="media_bug_answer_req=true"/>
+    <action application="set" data="execute_on_answer=record_session {{ recording_url }}/${uuid}.wav"/>
+    {% endif %}
+    <action application="export" data="nolocal:odoo_parent_uuid=${uuid}"/>
+    <action application="set" data="call_timeout=30"/>
+    <action application="set" data="hangup_after_bridge=true"/>
+    <action application="set" data="continue_on_fail=true"/>
+    <action application="bridge" data="user/{{ number }}@{{ fs_domain }}"/>
+  </condition>
+</extension>]]></field>
+        <field name="default_content"><![CDATA[<extension name="user_{{ number }}">
+  <condition field="destination_number" expression="^{{ number }}$">
+    <action application="set" data="odoo_called_user_id={{ user_id }}"/>
+    {% if exten_id %}
+    <action application="set" data="odoo_exten_id={{ exten_id }}"/>
+    {% endif %}
+    {% if record_calls and recording_url %}
+    <action application="set" data="RECORD_STEREO=true"/>
+    <action application="set" data="media_bug_answer_req=true"/>
+    <action application="set" data="execute_on_answer=record_session {{ recording_url }}/${uuid}.wav"/>
+    {% endif %}
+    <action application="export" data="nolocal:odoo_parent_uuid=${uuid}"/>
+    <action application="set" data="call_timeout=30"/>
+    <action application="set" data="hangup_after_bridge=true"/>
+    <action application="set" data="continue_on_fail=true"/>
+    <action application="bridge" data="user/{{ number }}@{{ fs_domain }}"/>
+  </condition>
+</extension>]]></field>
+    </record>
+
+    <record id="fs_template_dialplan_ivr" model="connect.freeswitch.template">
+        <field name="key">dialplan_ivr</field>
+        <field name="name">Dialplan - IVR</field>
+        <field name="section">dialplan</field>
+        <field name="description">Interactive Voice Response with play_and_get_digits and inline choice conditions.
+
+Variables:
+  callflow_id     - connect.callflow record ID
+  number          - Extension number (escaped for regex)
+  pgd_data        - play_and_get_digits parameter string
+  var_name        - Channel variable name for collected digits
+  choices         - List of dicts, each with:
+    digits_escaped  - Choice digits (escaped for regex)
+    dst_type        - Destination type: 'user' or 'other'
+    user_id         - connect.user ID (if dst_type == 'user')
+    user_number     - User extension number (if dst_type == 'user')
+    transfer_target - Transfer destination (if dst_type == 'other')
+  fs_domain       - FreeSWITCH SIP domain</field>
+        <field name="content"><![CDATA[<extension name="callflow_{{ callflow_id }}">
+  <condition field="destination_number" expression="^{{ number }}$" break="on-false">
+    <action application="answer"/>
+    <action application="sleep" data="500"/>
+    <action application="play_and_get_digits" data="{{ pgd_data }}"/>
+  </condition>
+  {% for choice in choices %}
+  <condition field="${{{ var_name }}}" expression="^{{ choice.digits_escaped }}$" break="on-true">
+    {% if choice.dst_type == 'user' %}
+    <action application="set" data="odoo_called_user_id={{ choice.user_id }}"/>
+    <action application="export" data="nolocal:odoo_parent_uuid=${uuid}"/>
+    <action application="set" data="call_timeout=30"/>
+    <action application="set" data="hangup_after_bridge=true"/>
+    <action application="set" data="continue_on_fail=true"/>
+    <action application="bridge" data="user/{{ choice.user_number }}@{{ fs_domain }}"/>
+    {% else %}
+    <action application="transfer" data="{{ choice.transfer_target }} XML default"/>
+    {% endif %}
+  </condition>
+  {% endfor %}
+</extension>]]></field>
+        <field name="default_content"><![CDATA[<extension name="callflow_{{ callflow_id }}">
+  <condition field="destination_number" expression="^{{ number }}$" break="on-false">
+    <action application="answer"/>
+    <action application="sleep" data="500"/>
+    <action application="play_and_get_digits" data="{{ pgd_data }}"/>
+  </condition>
+  {% for choice in choices %}
+  <condition field="${{{ var_name }}}" expression="^{{ choice.digits_escaped }}$" break="on-true">
+    {% if choice.dst_type == 'user' %}
+    <action application="set" data="odoo_called_user_id={{ choice.user_id }}"/>
+    <action application="export" data="nolocal:odoo_parent_uuid=${uuid}"/>
+    <action application="set" data="call_timeout=30"/>
+    <action application="set" data="hangup_after_bridge=true"/>
+    <action application="set" data="continue_on_fail=true"/>
+    <action application="bridge" data="user/{{ choice.user_number }}@{{ fs_domain }}"/>
+    {% else %}
+    <action application="transfer" data="{{ choice.transfer_target }} XML default"/>
+    {% endif %}
+  </condition>
+  {% endfor %}
+</extension>]]></field>
+    </record>
+
+    <record id="fs_template_dialplan_ring_group" model="connect.freeswitch.template">
+        <field name="key">dialplan_ring_group</field>
+        <field name="name">Dialplan - Ring Group</field>
+        <field name="section">dialplan</field>
+        <field name="description">Ring group that bridges to multiple users simultaneously.
+
+Variables:
+  callflow_id     - connect.callflow record ID
+  number          - Extension number (escaped for regex)
+  exten_id        - connect.exten record ID (may be empty)
+  record_calls    - Boolean, whether to record the call
+  recording_url   - URL for recording webhook (if record_calls)
+  bridge_string   - Comma-separated bridge endpoints
+</field>
+        <field name="content"><![CDATA[<extension name="callflow_ring_{{ callflow_id }}">
+  <condition field="destination_number" expression="^{{ number }}$">
+    {% if exten_id %}
+    <action application="set" data="odoo_exten_id={{ exten_id }}"/>
+    {% endif %}
+    {% if record_calls and recording_url %}
+    <action application="set" data="RECORD_STEREO=true"/>
+    <action application="set" data="media_bug_answer_req=true"/>
+    <action application="set" data="execute_on_answer=record_session {{ recording_url }}/${uuid}.wav"/>
+    {% endif %}
+    <action application="export" data="nolocal:odoo_parent_uuid=${uuid}"/>
+    <action application="set" data="call_timeout=30"/>
+    <action application="set" data="hangup_after_bridge=true"/>
+    {% if bridge_string %}
+    <action application="bridge" data="{{ bridge_string }}"/>
+    {% endif %}
+  </condition>
+</extension>]]></field>
+        <field name="default_content"><![CDATA[<extension name="callflow_ring_{{ callflow_id }}">
+  <condition field="destination_number" expression="^{{ number }}$">
+    {% if exten_id %}
+    <action application="set" data="odoo_exten_id={{ exten_id }}"/>
+    {% endif %}
+    {% if record_calls and recording_url %}
+    <action application="set" data="RECORD_STEREO=true"/>
+    <action application="set" data="media_bug_answer_req=true"/>
+    <action application="set" data="execute_on_answer=record_session {{ recording_url }}/${uuid}.wav"/>
+    {% endif %}
+    <action application="export" data="nolocal:odoo_parent_uuid=${uuid}"/>
+    <action application="set" data="call_timeout=30"/>
+    <action application="set" data="hangup_after_bridge=true"/>
+    {% if bridge_string %}
+    <action application="bridge" data="{{ bridge_string }}"/>
+    {% endif %}
+  </condition>
+</extension>]]></field>
+    </record>
+
+    <record id="fs_template_dialplan_inbound_did" model="connect.freeswitch.template">
+        <field name="key">dialplan_inbound_did</field>
+        <field name="name">Dialplan - Inbound DID</field>
+        <field name="section">dialplan</field>
+        <field name="description">Inbound DID routing from PSTN trunks.
+
+Variables:
+  phone_number    - DID phone number
+  number_id       - connect.number record ID
+  destination     - Destination type: 'user' or 'callflow'
+  transfer_target - Extension/number to transfer to (or empty if no destination)</field>
+        <field name="content"><![CDATA[<extension name="did_{{ phone_number }}">
+  <condition field="destination_number" expression="^{{ phone_number }}$">
+    <action application="set" data="odoo_call_direction=inbound"/>
+    <action application="set" data="odoo_number_id={{ number_id }}"/>
+    {% if transfer_target %}
+    <action application="transfer" data="{{ transfer_target }} XML default"/>
+    {% else %}
+    <action application="respond" data="404"/>
+    {% endif %}
+  </condition>
+</extension>]]></field>
+        <field name="default_content"><![CDATA[<extension name="did_{{ phone_number }}">
+  <condition field="destination_number" expression="^{{ phone_number }}$">
+    <action application="set" data="odoo_call_direction=inbound"/>
+    <action application="set" data="odoo_number_id={{ number_id }}"/>
+    {% if transfer_target %}
+    <action application="transfer" data="{{ transfer_target }} XML default"/>
+    {% else %}
+    <action application="respond" data="404"/>
+    {% endif %}
+  </condition>
+</extension>]]></field>
+    </record>
+
+    <record id="fs_template_dialplan_outgoing_route" model="connect.freeswitch.template">
+        <field name="key">dialplan_outgoing_route</field>
+        <field name="name">Dialplan - Outgoing Route</field>
+        <field name="section">dialplan</field>
+        <field name="description">Outbound call routing via SIP gateway.
+
+Variables:
+  route_id        - connect.freeswitch.outgoing_route record ID
+  pattern         - Regex pattern for destination matching
+  bridge_data     - Bridge string (sofia/gateway/name/number)</field>
+        <field name="content"><![CDATA[<extension name="outgoing_{{ route_id }}">
+  <condition field="destination_number" expression="{{ pattern }}">
+    <action application="set" data="odoo_call_direction=outgoing"/>
+    <action application="export" data="nolocal:absolute_codec_string=PCMU,PCMA"/>
+    <action application="bridge" data="{{ bridge_data }}"/>
+  </condition>
+</extension>]]></field>
+        <field name="default_content"><![CDATA[<extension name="outgoing_{{ route_id }}">
+  <condition field="destination_number" expression="{{ pattern }}">
+    <action application="set" data="odoo_call_direction=outgoing"/>
+    <action application="export" data="nolocal:absolute_codec_string=PCMU,PCMA"/>
+    <action application="bridge" data="{{ bridge_data }}"/>
+  </condition>
+</extension>]]></field>
+    </record>
+
+    <record id="fs_template_dialplan_system" model="connect.freeswitch.template">
+        <field name="key">dialplan_system</field>
+        <field name="name">Dialplan - System Extensions</field>
+        <field name="section">dialplan</field>
+        <field name="description">System utility extensions (echo test, etc.). No variables required.</field>
+        <field name="content"><![CDATA[<extension name="echo">
+  <condition field="destination_number" expression="^9196$">
+    <action application="answer"/>
+    <action application="echo"/>
+  </condition>
+</extension>]]></field>
+        <field name="default_content"><![CDATA[<extension name="echo">
+  <condition field="destination_number" expression="^9196$">
+    <action application="answer"/>
+    <action application="echo"/>
+  </condition>
+</extension>]]></field>
+    </record>
+
+    <!-- ==================== CONFIGURATION TEMPLATES ==================== -->
+
+    <record id="fs_template_config_sofia" model="connect.freeswitch.template">
+        <field name="key">config_sofia</field>
+        <field name="name">Configuration - Sofia SIP</field>
+        <field name="section">configuration</field>
+        <field name="description">Sofia SIP module configuration with external profile and gateways.
+
+Variables:
+  sofia_log_level - Sofia log level (0-9)
+  fs_domain       - FreeSWITCH SIP domain (may be empty)
+  gateways_xml    - Pre-rendered XML string of all gateway elements</field>
+        <field name="content"><![CDATA[<configuration name="sofia.conf" description="Sofia SIP">
+  <global_settings>
+    <param name="log-level" value="{{ sofia_log_level }}"/>
+  </global_settings>
+  <profiles>
+    <profile name="external">
+      <settings>
+        <param name="context" value="public"/>
+        <param name="sip-port" value="5080"/>
+        <param name="rtp-timer-name" value="soft"/>
+        <param name="codec-prefs" value="OPUS,PCMU,PCMA"/>
+        <param name="auth-calls" value="true"/>
+        {% if fs_domain %}
+        <param name="force-register-domain" value="{{ fs_domain }}"/>
+        <param name="force-realm" value="{{ fs_domain }}"/>
+        <param name="force-register-db-domain" value="{{ fs_domain }}"/>
+        {% endif %}
+      </settings>
+      <gateways>
+        {{ gateways_xml }}
+      </gateways>
+    </profile>
+  </profiles>
+</configuration>]]></field>
+        <field name="default_content"><![CDATA[<configuration name="sofia.conf" description="Sofia SIP">
+  <global_settings>
+    <param name="log-level" value="{{ sofia_log_level }}"/>
+  </global_settings>
+  <profiles>
+    <profile name="external">
+      <settings>
+        <param name="context" value="public"/>
+        <param name="sip-port" value="5080"/>
+        <param name="rtp-timer-name" value="soft"/>
+        <param name="codec-prefs" value="OPUS,PCMU,PCMA"/>
+        <param name="auth-calls" value="true"/>
+        {% if fs_domain %}
+        <param name="force-register-domain" value="{{ fs_domain }}"/>
+        <param name="force-realm" value="{{ fs_domain }}"/>
+        <param name="force-register-db-domain" value="{{ fs_domain }}"/>
+        {% endif %}
+      </settings>
+      <gateways>
+        {{ gateways_xml }}
+      </gateways>
+    </profile>
+  </profiles>
+</configuration>]]></field>
+    </record>
+
+    <record id="fs_template_config_sofia_gateway" model="connect.freeswitch.template">
+        <field name="key">config_sofia_gateway</field>
+        <field name="name">Configuration - SIP Gateway</field>
+        <field name="section">configuration</field>
+        <field name="description">Single SIP gateway element within the sofia profile.
+
+Variables:
+  name            - Gateway name
+  proxy           - SIP proxy address
+  username        - SIP username (may be empty)
+  password        - SIP password (may be empty)
+  register        - 'true' or 'false'
+  realm           - SIP realm (may be empty)
+  from_domain     - From domain (may be empty)
+  caller_id_in_from - Boolean
+  expire_seconds  - Registration expiry
+  retry_seconds   - Retry interval</field>
+        <field name="content"><![CDATA[<gateway name="{{ name }}">
+  <param name="proxy" value="{{ proxy }}"/>
+  {% if username %}
+  <param name="username" value="{{ username }}"/>
+  {% endif %}
+  {% if password %}
+  <param name="password" value="{{ password }}"/>
+  {% endif %}
+  <param name="register" value="{{ register }}"/>
+  {% if realm %}
+  <param name="realm" value="{{ realm }}"/>
+  {% endif %}
+  {% if from_domain %}
+  <param name="from-domain" value="{{ from_domain }}"/>
+  {% endif %}
+  {% if caller_id_in_from %}
+  <param name="caller-id-in-from" value="true"/>
+  {% endif %}
+  <param name="expire-seconds" value="{{ expire_seconds }}"/>
+  <param name="retry-seconds" value="{{ retry_seconds }}"/>
+</gateway>]]></field>
+        <field name="default_content"><![CDATA[<gateway name="{{ name }}">
+  <param name="proxy" value="{{ proxy }}"/>
+  {% if username %}
+  <param name="username" value="{{ username }}"/>
+  {% endif %}
+  {% if password %}
+  <param name="password" value="{{ password }}"/>
+  {% endif %}
+  <param name="register" value="{{ register }}"/>
+  {% if realm %}
+  <param name="realm" value="{{ realm }}"/>
+  {% endif %}
+  {% if from_domain %}
+  <param name="from-domain" value="{{ from_domain }}"/>
+  {% endif %}
+  {% if caller_id_in_from %}
+  <param name="caller-id-in-from" value="true"/>
+  {% endif %}
+  <param name="expire-seconds" value="{{ expire_seconds }}"/>
+  <param name="retry-seconds" value="{{ retry_seconds }}"/>
+</gateway>]]></field>
+    </record>
+
+    <record id="fs_template_config_xml_rpc" model="connect.freeswitch.template">
+        <field name="key">config_xml_rpc</field>
+        <field name="name">Configuration - XML RPC</field>
+        <field name="section">configuration</field>
+        <field name="description">XML-RPC server configuration for API access.
+
+Variables:
+  port     - HTTP port
+  user     - Auth username
+  password - Auth password</field>
+        <field name="content"><![CDATA[<configuration name="xml_rpc.conf" description="XML RPC">
+  <settings>
+    <param name="http-port" value="{{ port }}"/>
+    <param name="auth-user" value="{{ user }}"/>
+    <param name="auth-pass" value="{{ password }}"/>
+    <param name="auth-realm" value="freeswitch"/>
+  </settings>
+</configuration>]]></field>
+        <field name="default_content"><![CDATA[<configuration name="xml_rpc.conf" description="XML RPC">
+  <settings>
+    <param name="http-port" value="{{ port }}"/>
+    <param name="auth-user" value="{{ user }}"/>
+    <param name="auth-pass" value="{{ password }}"/>
+    <param name="auth-realm" value="freeswitch"/>
+  </settings>
+</configuration>]]></field>
+    </record>
+
+</odoo>

--- a/connect_freeswitch/deploy/Dockerfile
+++ b/connect_freeswitch/deploy/Dockerfile
@@ -128,8 +128,9 @@ RUN mkdir -p /opt/piper/models \
 FROM debian:bookworm-slim
 
 # Minimal runtime packages (libc, libgcc, etc. already in base image)
+# python3 is needed for ACME cert extraction at startup
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates wget \
+    ca-certificates wget python3-minimal openssl \
     && rm -rf /var/lib/apt/lists/*
 
 # FreeSWITCH installation

--- a/connect_freeswitch/deploy/docker-entrypoint.sh
+++ b/connect_freeswitch/deploy/docker-entrypoint.sh
@@ -3,6 +3,8 @@ set -e
 
 BASEURL=http://files.freeswitch.org
 SOUNDS_DIR=/usr/share/freeswitch/sounds
+TLS_DIR=/usr/local/freeswitch/etc/freeswitch/tls
+ACME_FILE=/etc/traefik/acme.json
 
 download_sounds() {
     SRATES=$(echo "$SOUND_RATES" | sed -e 's/:/ /g')
@@ -33,7 +35,97 @@ download_sounds() {
     done
 }
 
+setup_tls() {
+    mkdir -p "$TLS_DIR"
+
+    if [ -f "$ACME_FILE" ] && [ -n "$FS_DOMAIN" ]; then
+        echo "Extracting TLS certificate for $FS_DOMAIN from Traefik ACME..."
+        # Extract cert and key for FS_DOMAIN from Traefik acme.json
+        # acme.json stores certs as base64-encoded PEM
+        CERT=$(python3 -c "
+import json, base64, sys
+try:
+    with open('$ACME_FILE') as f:
+        data = json.load(f)
+    for resolver in data.values():
+        for cert in (resolver.get('Certificates') or []):
+            main = cert.get('domain', {}).get('main', '')
+            sans = cert.get('domain', {}).get('sans') or []
+            if main == '$FS_DOMAIN' or '$FS_DOMAIN' in sans:
+                print(base64.b64decode(cert['certificate']).decode(), end='')
+                sys.exit(0)
+    # Try wildcard match
+    parts = '$FS_DOMAIN'.split('.', 1)
+    if len(parts) == 2:
+        wildcard = '*.' + parts[1]
+        for resolver in data.values():
+            for cert in (resolver.get('Certificates') or []):
+                main = cert.get('domain', {}).get('main', '')
+                sans = cert.get('domain', {}).get('sans') or []
+                if main == wildcard or wildcard in sans:
+                    print(base64.b64decode(cert['certificate']).decode(), end='')
+                    sys.exit(0)
+    sys.exit(1)
+except Exception as e:
+    print(str(e), file=sys.stderr)
+    sys.exit(1)
+" 2>/dev/null)
+
+        KEY=$(python3 -c "
+import json, base64, sys
+try:
+    with open('$ACME_FILE') as f:
+        data = json.load(f)
+    for resolver in data.values():
+        for cert in (resolver.get('Certificates') or []):
+            main = cert.get('domain', {}).get('main', '')
+            sans = cert.get('domain', {}).get('sans') or []
+            if main == '$FS_DOMAIN' or '$FS_DOMAIN' in sans:
+                print(base64.b64decode(cert['key']).decode(), end='')
+                sys.exit(0)
+    parts = '$FS_DOMAIN'.split('.', 1)
+    if len(parts) == 2:
+        wildcard = '*.' + parts[1]
+        for resolver in data.values():
+            for cert in (resolver.get('Certificates') or []):
+                main = cert.get('domain', {}).get('main', '')
+                sans = cert.get('domain', {}).get('sans') or []
+                if main == wildcard or wildcard in sans:
+                    print(base64.b64decode(cert['key']).decode(), end='')
+                    sys.exit(0)
+    sys.exit(1)
+except Exception as e:
+    print(str(e), file=sys.stderr)
+    sys.exit(1)
+" 2>/dev/null)
+
+        if [ -n "$CERT" ] && [ -n "$KEY" ]; then
+            # Combine key + cert into PEM files (FS expects key first)
+            printf '%s\n%s' "$KEY" "$CERT" > "$TLS_DIR/wss.pem"
+            cp "$TLS_DIR/wss.pem" "$TLS_DIR/dtls-srtp.pem"
+            echo "TLS certificate installed from Traefik ACME for $FS_DOMAIN"
+            return
+        fi
+        echo "Warning: certificate for $FS_DOMAIN not found in ACME store"
+    fi
+
+    # Fallback: generate self-signed certificate if none exists
+    if [ ! -f "$TLS_DIR/wss.pem" ]; then
+        echo "Generating self-signed TLS certificate..."
+        openssl req -x509 -nodes -days 3650 \
+            -newkey rsa:4096 \
+            -keyout "$TLS_DIR/key.pem" \
+            -out "$TLS_DIR/cert.pem" \
+            -subj "/C=US/CN=${FS_DOMAIN:-FreeSWITCH}" 2>/dev/null
+        cat "$TLS_DIR/key.pem" "$TLS_DIR/cert.pem" > "$TLS_DIR/wss.pem"
+        cp "$TLS_DIR/wss.pem" "$TLS_DIR/dtls-srtp.pem"
+        rm -f "$TLS_DIR/key.pem" "$TLS_DIR/cert.pem"
+        echo "Self-signed TLS certificate generated"
+    fi
+}
+
 download_sounds
+setup_tls
 
 trap 'freeswitch -stop' TERM
 

--- a/connect_freeswitch/deploy/freeswitch/conf/autoload_configs/xml_curl.conf.xml
+++ b/connect_freeswitch/deploy/freeswitch/conf/autoload_configs/xml_curl.conf.xml
@@ -5,8 +5,12 @@
       <param name="timeout" value="10"/>
     </binding>
     <binding name="odoo-dialplan">
-      <param name="gateway-url" value="$${odoo_url}/freeswitch/xml" formula="exten=$${destination_number}"/>
+      <param name="gateway-url" value="$${odoo_url}/freeswitch/xml"/>
       <param name="bindings" value="dialplan"/>
+    </binding>
+    <binding name="odoo-configuration">
+      <param name="gateway-url" value="$${odoo_url}/freeswitch/xml"/>
+      <param name="bindings" value="configuration"/>
     </binding>
   </bindings>
 </configuration>

--- a/connect_freeswitch/models/__init__.py
+++ b/connect_freeswitch/models/__init__.py
@@ -1,4 +1,5 @@
 from . import call
+from . import fs_template
 from . import endpoint
 from . import exten
 from . import fs_callflow

--- a/connect_freeswitch/models/exten.py
+++ b/connect_freeswitch/models/exten.py
@@ -1,6 +1,5 @@
 import logging
 import re
-from xml.etree import ElementTree as ET
 from odoo import models
 
 logger = logging.getLogger(__name__)
@@ -9,14 +8,13 @@ logger = logging.getLogger(__name__)
 class Exten(models.Model):
     _inherit = 'connect.exten'
 
-    def generate_dialplan(self, context_el, params):
+    def generate_dialplan(self, params):
         """Generate FreeSWITCH dialplan XML for this extension."""
         self.ensure_one()
         if not self.dst:
-            ext = ET.SubElement(context_el, 'extension', name='ext_{}'.format(self.number))
-            condition = ET.SubElement(ext, 'condition',
-                field='destination_number', expression='^{}$'.format(re.escape(self.number)))
-            ET.SubElement(condition, 'action', application='respond', data='404')
-            return
+            return ('<extension name="ext_{number}">'
+                    '<condition field="destination_number" expression="^{number}$">'
+                    '<action application="respond" data="404"/>'
+                    '</condition></extension>').format(number=re.escape(self.number))
 
-        self.dst.generate_dialplan(context_el, params, exten=self)
+        return self.dst.generate_dialplan(params, exten=self)

--- a/connect_freeswitch/models/fs_callflow.py
+++ b/connect_freeswitch/models/fs_callflow.py
@@ -1,6 +1,5 @@
 import logging
 import re
-from xml.etree import ElementTree as ET
 from odoo import models
 
 logger = logging.getLogger(__name__)
@@ -9,7 +8,7 @@ logger = logging.getLogger(__name__)
 class CallFlow(models.Model):
     _inherit = 'connect.callflow'
 
-    def generate_dialplan(self, context_el, params, exten=None):
+    def generate_dialplan(self, params, exten=None):
         """Generate FreeSWITCH dialplan XML for this callflow.
 
         For IVR (gather_input): generates play_and_get_digits with inline
@@ -20,37 +19,23 @@ class CallFlow(models.Model):
         number = exten.number if exten else self.exten_number or str(self.id)
 
         if self.gather_input and self.prompt_message and self.choices:
-            self._generate_ivr_dialplan(context_el, number)
+            return self._generate_ivr_dialplan(number)
         elif self.ring_users:
-            self._generate_ring_group_dialplan(context_el, number, exten)
+            return self._generate_ring_group_dialplan(number, exten)
         else:
-            # No actions configured
-            ext = ET.SubElement(context_el, 'extension', name='callflow_{}'.format(self.id))
-            condition = ET.SubElement(ext, 'condition',
-                field='destination_number', expression='^{}$'.format(re.escape(number)))
-            ET.SubElement(condition, 'action', application='respond', data='404')
+            return ('<extension name="callflow_{id}">'
+                    '<condition field="destination_number" expression="^{number}$">'
+                    '<action application="respond" data="404"/>'
+                    '</condition></extension>').format(
+                        id=self.id, number=re.escape(number))
 
-    def _generate_ivr_dialplan(self, context_el, number):
+    def _generate_ivr_dialplan(self, number):
         """Generate IVR dialplan with play_and_get_digits + inline choice conditions."""
-        ext = ET.SubElement(context_el, 'extension', name='callflow_{}'.format(self.id))
-
-        # First condition: match destination number
-        main_condition = ET.SubElement(ext, 'condition',
-            field='destination_number',
-            expression='^{}$'.format(re.escape(number)))
-        main_condition.set('break', 'on-false')
-
-        ET.SubElement(main_condition, 'action', application='answer')
-        ET.SubElement(main_condition, 'action', application='sleep', data='500')
-
-        # Build play_and_get_digits parameters
-        # Syntax: <min> <max> <tries> <timeout> <terminators> <file> <invalid_file>
-        #         <var_name> <regexp> <digit_timeout> [<transfer_on_failure>]
         var_name = 'cf_digit_{}'.format(self.id)
         min_digits = 1
         max_digits = self.gather_digits or 1
         tries = 3
-        timeout = (self.gather_timeout or 5) * 1000  # Convert to milliseconds
+        timeout = (self.gather_timeout or 5) * 1000
         prompt = self.prompt_message or ''
         invalid_msg = self.invalid_input_message or ''
         lang = self._get_piper_language()
@@ -58,7 +43,6 @@ class CallFlow(models.Model):
         prompt_file = 'speak:piper|{}|{}'.format(lang, prompt) if prompt else 'silence_stream://250'
         invalid_file = 'speak:piper|{}|{}'.format(lang, invalid_msg) if invalid_msg else 'silence_stream://250'
 
-        # Collect valid digit patterns from choices
         valid_digits = '|'.join(
             re.escape(c.choice_digits) for c in self.choices if c.choice_digits)
         digit_regexp = '^({})$'.format(valid_digits) if valid_digits else r'\d+'
@@ -67,67 +51,50 @@ class CallFlow(models.Model):
             min=min_digits, max=max_digits, tries=tries, timeout=timeout,
             prompt=prompt_file, invalid=invalid_file, var=var_name, regexp=digit_regexp)
 
-        ET.SubElement(main_condition, 'action', application='play_and_get_digits',
-            data=pgd_data)
+        fs_domain = self.env['connect.settings'].sudo().get_param('freeswitch_domain') or '${domain}'
 
-        # Add inline conditions for each choice
+        choices = []
         for choice in self.choices:
             if not choice.choice_digits or not choice.exten:
                 continue
-
-            choice_condition = ET.SubElement(ext, 'condition',
-                field='${{{}}}'.format(var_name),
-                expression='^{}$'.format(re.escape(choice.choice_digits)))
-            choice_condition.set('break', 'on-true')
-
-            # Generate the choice destination's actions inline
             dst = choice.exten.dst
-            if dst:
-                if dst._name == 'connect.user':
-                    self._add_user_bridge_actions(choice_condition, dst)
-                elif dst._name == 'connect.callflow':
-                    # Nested callflow: transfer to it
-                    nested_number = choice.exten.number
-                    ET.SubElement(choice_condition, 'action',
-                        application='transfer',
-                        data='{} XML default'.format(nested_number))
-                else:
-                    ET.SubElement(choice_condition, 'action',
-                        application='transfer',
-                        data='{} XML default'.format(choice.exten.number))
+            if dst and dst._name == 'connect.user':
+                user_number = dst.exten_number or dst.username
+                choices.append({
+                    'digits_escaped': re.escape(choice.choice_digits),
+                    'dst_type': 'user',
+                    'user_id': dst.id,
+                    'user_number': user_number,
+                    'transfer_target': '',
+                })
+            else:
+                choices.append({
+                    'digits_escaped': re.escape(choice.choice_digits),
+                    'dst_type': 'other',
+                    'user_id': '',
+                    'user_number': '',
+                    'transfer_target': choice.exten.number,
+                })
 
-    def _generate_ring_group_dialplan(self, context_el, number, exten=None):
+        return self.env['connect.freeswitch.template'].render('dialplan_ivr', {
+            'callflow_id': self.id,
+            'number': re.escape(number),
+            'pgd_data': pgd_data,
+            'var_name': var_name,
+            'choices': choices,
+            'fs_domain': fs_domain,
+        })
+
+    def _generate_ring_group_dialplan(self, number, exten=None):
         """Generate ring group dialplan bridging to multiple users."""
-        ext = ET.SubElement(context_el, 'extension', name='callflow_ring_{}'.format(self.id))
-        condition = ET.SubElement(ext, 'condition',
-            field='destination_number', expression='^{}$'.format(re.escape(number)))
+        base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url') or ''
+        recording_url = ''
+        if self.record_calls and base_url:
+            recording_url = '{}freeswitch/webhook/recording'.format(
+                base_url if base_url.endswith('/') else base_url + '/')
 
-        if exten:
-            ET.SubElement(condition, 'action', application='set',
-                data='odoo_exten_id={}'.format(exten.id))
+        fs_domain = self.env['connect.settings'].sudo().get_param('freeswitch_domain') or '${domain}'
 
-        # Call recording
-        if self.record_calls:
-            base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url') or ''
-            if base_url:
-                recording_url = '{}freeswitch/webhook/recording'.format(
-                    base_url if base_url.endswith('/') else base_url + '/')
-                ET.SubElement(condition, 'action', application='set',
-                    data='RECORD_STEREO=true')
-                ET.SubElement(condition, 'action', application='set',
-                    data='media_bug_answer_req=true')
-                ET.SubElement(condition, 'action', application='set',
-                    data='execute_on_answer=record_session {}/{}.wav'.format(
-                        recording_url, '${uuid}'))
-
-        # Export parent UUID to B-leg for CDR linking
-        ET.SubElement(condition, 'action', application='export',
-            data='nolocal:odoo_parent_uuid=${uuid}')
-
-        ET.SubElement(condition, 'action', application='set', data='call_timeout=30')
-        ET.SubElement(condition, 'action', application='set', data='hangup_after_bridge=true')
-
-        # Build bridge string with all users
         bridge_parts = []
         for user in self.ring_users:
             endpoint = self.env['connect.endpoint'].sudo().search([
@@ -135,30 +102,19 @@ class CallFlow(models.Model):
                 ('active', '=', True),
                 '|', ('sip_enabled', '=', True), ('webrtc_enabled', '=', True)
             ], limit=1)
-            fs_domain = self.env['connect.settings'].sudo().get_param('freeswitch_domain') or '${domain}'
             user_number = user.exten_number or user.username
             bridge_parts.append('user/{}@{}'.format(user_number, fs_domain))
 
-        if bridge_parts:
-            ET.SubElement(condition, 'action', application='bridge',
-                data=','.join(bridge_parts))
+        return self.env['connect.freeswitch.template'].render('dialplan_ring_group', {
+            'callflow_id': self.id,
+            'number': re.escape(number),
+            'exten_id': exten.id if exten else None,
+            'record_calls': self.record_calls,
+            'recording_url': recording_url,
+            'bridge_string': ','.join(bridge_parts),
+        })
 
     def _get_piper_language(self):
         """Map callflow language (e.g. 'en-US') to piper short code (e.g. 'en')."""
         lang = self.language or 'en-US'
         return lang.split('-')[0]
-
-    def _add_user_bridge_actions(self, parent_el, user):
-        """Add bridge actions for a user directly into a parent XML element."""
-        fs_domain = self.env['connect.settings'].sudo().get_param('freeswitch_domain') or '${domain}'
-        user_number = user.exten_number or user.username
-
-        ET.SubElement(parent_el, 'action', application='set',
-            data='odoo_called_user_id={}'.format(user.id))
-        ET.SubElement(parent_el, 'action', application='export',
-            data='nolocal:odoo_parent_uuid=${uuid}')
-        ET.SubElement(parent_el, 'action', application='set', data='call_timeout=30')
-        ET.SubElement(parent_el, 'action', application='set', data='hangup_after_bridge=true')
-        ET.SubElement(parent_el, 'action', application='set', data='continue_on_fail=true')
-        ET.SubElement(parent_el, 'action', application='bridge',
-            data='user/{}@{}'.format(user_number, fs_domain))

--- a/connect_freeswitch/models/fs_template.py
+++ b/connect_freeswitch/models/fs_template.py
@@ -1,0 +1,72 @@
+import jinja2
+import logging
+from odoo import api, fields, models, release, tools
+if release.version_info[0] >= 19:
+    from odoo.models import Constraint
+
+logger = logging.getLogger(__name__)
+
+
+class FreeSwitchTemplate(models.Model):
+    _name = 'connect.freeswitch.template'
+    _description = 'FreeSWITCH XML Template'
+    _order = 'key'
+
+    key = fields.Char(required=True, readonly=True, copy=False)
+    name = fields.Char(required=True)
+    description = fields.Text(readonly=True,
+        help='Documents the available Jinja2 context variables for this template')
+    section = fields.Selection([
+        ('directory', 'Directory'),
+        ('dialplan', 'Dialplan'),
+        ('configuration', 'Configuration'),
+    ], required=True, readonly=True)
+    content = fields.Text(required=True)
+    default_content = fields.Text(readonly=True)
+    is_customized = fields.Boolean(compute='_compute_is_customized', store=True)
+
+    if release.version_info[0] >= 19:
+        _key_uniq = Constraint('UNIQUE(key)', 'Template key must be unique!')
+    else:
+        _sql_constraints = [
+            ('key_uniq', 'UNIQUE(key)', 'Template key must be unique!'),
+        ]
+
+    @api.depends('content', 'default_content')
+    def _compute_is_customized(self):
+        for rec in self:
+            rec.is_customized = (rec.content or '') != (rec.default_content or '')
+
+    def write(self, vals):
+        result = super().write(vals)
+        if 'content' in vals:
+            self._get_template_content.clear_cache(self)
+        return result
+
+    def unlink(self):
+        self._get_template_content.clear_cache(self)
+        return super().unlink()
+
+    def reset_to_default(self):
+        for rec in self:
+            rec.content = rec.default_content
+
+    @tools.ormcache('key')
+    def _get_template_content(self, key):
+        rec = self.sudo().search([('key', '=', key)], limit=1)
+        if not rec:
+            return None
+        return rec.content
+
+    @api.model
+    def render(self, key, context):
+        """Look up template by key and render with the given context dict."""
+        content = self._get_template_content(key)
+        if content is None:
+            raise ValueError("FreeSWITCH template '{}' not found".format(key))
+        env = jinja2.Environment(
+            autoescape=False,
+            undefined=jinja2.StrictUndefined,
+        )
+        tmpl = env.from_string(content)
+        return tmpl.render(**context)

--- a/connect_freeswitch/models/fs_template.py
+++ b/connect_freeswitch/models/fs_template.py
@@ -40,11 +40,11 @@ class FreeSwitchTemplate(models.Model):
     def write(self, vals):
         result = super().write(vals)
         if 'content' in vals:
-            self._get_template_content.clear_cache(self)
+            self.env.registry.clear_cache()
         return result
 
     def unlink(self):
-        self._get_template_content.clear_cache(self)
+        self.env.registry.clear_cache()
         return super().unlink()
 
     def reset_to_default(self):

--- a/connect_freeswitch/models/fs_user.py
+++ b/connect_freeswitch/models/fs_user.py
@@ -1,6 +1,5 @@
 import logging
 import re
-from xml.etree import ElementTree as ET
 from odoo import models
 
 logger = logging.getLogger(__name__)
@@ -9,49 +8,24 @@ logger = logging.getLogger(__name__)
 class User(models.Model):
     _inherit = 'connect.user'
 
-    def generate_dialplan(self, context_el, params, exten=None):
+    def generate_dialplan(self, params, exten=None):
         """Generate FreeSWITCH dialplan to bridge to this user's endpoints."""
         self.ensure_one()
         number = exten.number if exten else self.exten_number or self.username
         base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url') or ''
 
-        ext = ET.SubElement(context_el, 'extension', name='user_{}'.format(number))
-        condition = ET.SubElement(ext, 'condition',
-            field='destination_number', expression='^{}$'.format(re.escape(number)))
-
-        # Tracking variables
-        ET.SubElement(condition, 'action', application='set',
-            data='odoo_called_user_id={}'.format(self.id))
-        if exten:
-            ET.SubElement(condition, 'action', application='set',
-                data='odoo_exten_id={}'.format(exten.id))
-
-        # Call recording
+        recording_url = ''
         if self.record_calls and base_url:
             recording_url = '{}freeswitch/webhook/recording'.format(
                 base_url if base_url.endswith('/') else base_url + '/')
-            ET.SubElement(condition, 'action', application='set',
-                data='RECORD_STEREO=true')
-            ET.SubElement(condition, 'action', application='set',
-                data='media_bug_answer_req=true')
-            ET.SubElement(condition, 'action', application='set',
-                data='execute_on_answer=record_session {}/{}.wav'.format(
-                    recording_url, '${uuid}'))
-
-        # Export parent UUID to B-leg for CDR linking
-        ET.SubElement(condition, 'action', application='export',
-            data='nolocal:odoo_parent_uuid=${uuid}')
-
-        # Bridge settings
-        ET.SubElement(condition, 'action', application='set',
-            data='call_timeout=30')
-        ET.SubElement(condition, 'action', application='set',
-            data='hangup_after_bridge=true')
-        ET.SubElement(condition, 'action', application='set',
-            data='continue_on_fail=true')
 
         fs_domain = self.env['connect.settings'].sudo().get_param('freeswitch_domain') or '${domain}'
 
-        # Bridge to user (uses dial-string from directory which includes SIP + Verto)
-        ET.SubElement(condition, 'action', application='bridge',
-            data='user/{}@{}'.format(number, fs_domain))
+        return self.env['connect.freeswitch.template'].render('dialplan_user_bridge', {
+            'number': re.escape(number),
+            'user_id': self.id,
+            'exten_id': exten.id if exten else None,
+            'record_calls': self.record_calls,
+            'recording_url': recording_url,
+            'fs_domain': fs_domain,
+        })

--- a/connect_freeswitch/models/gateway.py
+++ b/connect_freeswitch/models/gateway.py
@@ -1,5 +1,7 @@
 import logging
+import re
 from odoo import fields, models, api, release
+from odoo.exceptions import ValidationError
 if release.version_info[0] >= 19:
     from odoo.models import Constraint
 
@@ -29,6 +31,15 @@ class FreeSwitchGateway(models.Model):
         _sql_constraints = [
             ('name_uniq', 'UNIQUE(name)', 'Gateway name must be unique!'),
         ]
+
+    @api.constrains('name')
+    def _check_name(self):
+        for record in self:
+            if record.name and not re.match(r'^[a-zA-Z0-9_.-]+$', record.name):
+                raise ValidationError(
+                    "Gateway name '{}' contains invalid characters. "
+                    "Only letters, digits, hyphens, underscores and dots "
+                    "are allowed.".format(record.name))
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/connect_freeswitch/models/gateway.py
+++ b/connect_freeswitch/models/gateway.py
@@ -51,23 +51,18 @@ class FreeSwitchGateway(models.Model):
         self.env['connect.settings'].freeswitch_api(
             'sofia', 'profile external restart reloadxml')
 
-    def generate_sofia_gateway_xml(self, parent_el):
-        """Generate FreeSWITCH gateway XML element."""
-        from xml.etree import ElementTree as ET
+    def generate_sofia_gateway_xml(self):
+        """Generate FreeSWITCH gateway XML string."""
         self.ensure_one()
-        gw = ET.SubElement(parent_el, 'gateway', name=self.name)
-        ET.SubElement(gw, 'param', name='proxy', value=self.proxy)
-        if self.username:
-            ET.SubElement(gw, 'param', name='username', value=self.username)
-        if self.password:
-            ET.SubElement(gw, 'param', name='password', value=self.password)
-        ET.SubElement(gw, 'param', name='register', value='true' if self.register else 'false')
-        if self.realm:
-            ET.SubElement(gw, 'param', name='realm', value=self.realm)
-        if self.from_domain:
-            ET.SubElement(gw, 'param', name='from-domain', value=self.from_domain)
-        if self.caller_id_in_from:
-            ET.SubElement(gw, 'param', name='caller-id-in-from', value='true')
-        ET.SubElement(gw, 'param', name='expire-seconds', value=str(self.expire_seconds))
-        ET.SubElement(gw, 'param', name='retry-seconds', value=str(self.retry_seconds))
-        return gw
+        return self.env['connect.freeswitch.template'].render('config_sofia_gateway', {
+            'name': self.name,
+            'proxy': self.proxy,
+            'username': self.username or '',
+            'password': self.password or '',
+            'register': 'true' if self.register else 'false',
+            'realm': self.realm or '',
+            'from_domain': self.from_domain or '',
+            'caller_id_in_from': self.caller_id_in_from,
+            'expire_seconds': str(self.expire_seconds),
+            'retry_seconds': str(self.retry_seconds),
+        })

--- a/connect_freeswitch/models/number.py
+++ b/connect_freeswitch/models/number.py
@@ -1,6 +1,5 @@
 import logging
 import re
-from xml.etree import ElementTree as ET
 from odoo import models
 
 logger = logging.getLogger(__name__)
@@ -9,31 +8,19 @@ logger = logging.getLogger(__name__)
 class Number(models.Model):
     _inherit = 'connect.number'
 
-    def generate_dialplan(self, context_el, params):
-        """Generate FreeSWITCH dialplan for inbound DID routing."""
+    def generate_dialplan(self, params):
+        """Generate FreeSWITCH dialplan XML for inbound DID routing."""
         self.ensure_one()
 
-        ext = ET.SubElement(context_el, 'extension',
-            name='did_{}'.format(self.phone_number))
-        condition = ET.SubElement(ext, 'condition',
-            field='destination_number',
-            expression='^{}$'.format(re.escape(self.phone_number)))
-
-        ET.SubElement(condition, 'action', application='set',
-            data='odoo_call_direction=inbound')
-        ET.SubElement(condition, 'action', application='set',
-            data='odoo_number_id={}'.format(self.id))
-
-        # Route to destination
+        transfer_target = ''
         if self.destination == 'user' and self.user:
-            # Transfer to user's extension in default context
-            user_number = self.user.exten_number or self.user.username
-            ET.SubElement(condition, 'action', application='transfer',
-                data='{} XML default'.format(user_number))
+            transfer_target = self.user.exten_number or self.user.username
         elif self.destination == 'callflow' and self.callflow:
-            # Transfer to callflow's extension in default context
-            cf_number = self.callflow.exten_number or str(self.callflow.id)
-            ET.SubElement(condition, 'action', application='transfer',
-                data='{} XML default'.format(cf_number))
-        else:
-            ET.SubElement(condition, 'action', application='respond', data='404')
+            transfer_target = self.callflow.exten_number or str(self.callflow.id)
+
+        return self.env['connect.freeswitch.template'].render('dialplan_inbound_did', {
+            'phone_number': re.escape(self.phone_number),
+            'number_id': self.id,
+            'destination': self.destination,
+            'transfer_target': transfer_target,
+        })

--- a/connect_freeswitch/models/outgoing_route.py
+++ b/connect_freeswitch/models/outgoing_route.py
@@ -1,6 +1,5 @@
 import logging
 import re
-from xml.etree import ElementTree as ET
 from odoo import fields, models
 
 logger = logging.getLogger(__name__)
@@ -29,8 +28,8 @@ class FreeSwitchOutgoingRoute(models.Model):
             number = prefix + number
         return 'sofia/gateway/{}/{}'.format(gateway_name, number)
 
-    def generate_dialplan(self, context_el, params):
-        """Generate outgoing route dialplan for matching routes."""
+    def generate_dialplan(self, params):
+        """Generate outgoing route dialplan for matching routes. Returns XML string or empty string."""
         destination = params.get('Caller-Destination-Number', '')
         routes = self.sudo().search([('active', '=', True)])
 
@@ -38,19 +37,14 @@ class FreeSwitchOutgoingRoute(models.Model):
             if not re.match(route.pattern, destination):
                 continue
 
-            ext = ET.SubElement(context_el, 'extension', name='outgoing_{}'.format(route.id))
-            condition = ET.SubElement(ext, 'condition',
-                field='destination_number', expression=route.pattern)
-            ET.SubElement(condition, 'action', application='set',
-                data='odoo_call_direction=outgoing')
-            # Force PSTN-compatible codecs for the outbound leg
-            ET.SubElement(condition, 'action', application='export',
-                data='nolocal:absolute_codec_string=PCMU,PCMA')
-
             bridge_data = self._build_bridge_data(
                 route.gateway.name, destination,
                 strip=route.strip, prefix=route.prefix or '')
-            ET.SubElement(condition, 'action', application='bridge', data=bridge_data)
-            return True
 
-        return False
+            return self.env['connect.freeswitch.template'].render('dialplan_outgoing_route', {
+                'route_id': route.id,
+                'pattern': route.pattern,
+                'bridge_data': bridge_data,
+            })
+
+        return ''

--- a/connect_freeswitch/models/settings.py
+++ b/connect_freeswitch/models/settings.py
@@ -149,7 +149,7 @@ class Settings(models.Model):
         # 3. Registered endpoints
         fs_registrations = '0'
         reg_response = self.freeswitch_api(
-            'sofia', 'xmlstatus profile internal reg')
+            'sofia', 'xmlstatus profile external reg')
         if reg_response and not reg_response.startswith('-ERR'):
             try:
                 root = ET.fromstring(reg_response)

--- a/connect_freeswitch/models/settings.py
+++ b/connect_freeswitch/models/settings.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
+import re
+import xml.etree.ElementTree as ET
 import xmlrpc.client
 
 from odoo import api, fields, models
@@ -73,6 +75,13 @@ class Settings(models.Model):
         help="FreeSWITCH mod_xml_rpc password",
     )
 
+    # Status fields (populated by check_freeswitch_status button)
+    freeswitch_status = fields.Char(string="Server Status", readonly=True)
+    freeswitch_uptime = fields.Char(string="Uptime", readonly=True)
+    freeswitch_calls = fields.Char(string="Active Calls", readonly=True)
+    freeswitch_registrations = fields.Char(string="Registered Endpoints", readonly=True)
+    freeswitch_gateway_statuses = fields.Text(string="Gateway Statuses", readonly=True)
+
     @api.model
     def freeswitch_api(self, command, args=''):
         """Execute a FreeSWITCH API command via mod_xml_rpc.
@@ -96,6 +105,95 @@ class Settings(models.Model):
         except Exception as e:
             logger.error("FreeSWITCH XML-RPC error: %s", e)
             return False
+
+    def check_freeswitch_status(self):
+        """Fetch live status from FreeSWITCH and update display fields."""
+        self.ensure_one()
+        down_vals = {
+            'freeswitch_status': 'DOWN (unreachable)',
+            'freeswitch_uptime': '',
+            'freeswitch_calls': '',
+            'freeswitch_registrations': '',
+            'freeswitch_gateway_statuses': '',
+        }
+
+        # 1. Basic status
+        status_response = self.freeswitch_api('status')
+        if not status_response:
+            self.write(down_vals)
+            return
+
+        fs_version = ''
+        fs_uptime = ''
+        for line in status_response.splitlines():
+            line = line.strip()
+            if line.startswith('UP '):
+                fs_uptime = line[3:]
+            version_match = re.search(
+                r'FreeSWITCH \(Version ([^)]+)\)', line)
+            if version_match:
+                fs_version = version_match.group(1)
+
+        fs_status = 'UP'
+        if fs_version:
+            fs_status = 'UP — {}'.format(fs_version)
+
+        # 2. Active calls
+        fs_calls = '0'
+        calls_response = self.freeswitch_api('show', 'calls count')
+        if calls_response:
+            m = re.search(r'(\d+)\s+total', calls_response)
+            if m:
+                fs_calls = m.group(1)
+
+        # 3. Registered endpoints
+        fs_registrations = '0'
+        reg_response = self.freeswitch_api(
+            'sofia', 'xmlstatus profile internal reg')
+        if reg_response and not reg_response.startswith('-ERR'):
+            try:
+                root = ET.fromstring(reg_response)
+                regs = root.findall('.//registration')
+                fs_registrations = str(len(regs))
+            except ET.ParseError:
+                fs_registrations = 'parse error'
+
+        # 4. Gateway statuses
+        gateways = self.env['connect.freeswitch.gateway'].search(
+            [('active', '=', True)])
+        status_map = {
+            'REGED': 'UP (Registered)',
+            'NOREG': 'UP (No Registration)',
+            'UNREGED': 'DOWN (Unregistered)',
+            'TRYING': 'TRYING',
+            'FAIL_WAIT': 'DOWN (Failed)',
+        }
+        gateway_lines = []
+        for gw in gateways:
+            gw_response = self.freeswitch_api(
+                'sofia', 'xmlstatus gateway {}'.format(gw.name))
+            gw_status = 'Unknown'
+            if gw_response and not gw_response.startswith('-ERR'):
+                try:
+                    gw_root = ET.fromstring(gw_response)
+                    raw = gw_root.findtext('status', 'Unknown').strip()
+                    gw_status = status_map.get(raw, raw)
+                except ET.ParseError:
+                    gw_status = 'Parse error'
+            elif gw_response and gw_response.startswith('-ERR'):
+                gw_status = 'Not found in sofia'
+            else:
+                gw_status = 'Unreachable'
+            gateway_lines.append('{}: {}'.format(gw.name, gw_status))
+
+        self.write({
+            'freeswitch_status': fs_status,
+            'freeswitch_uptime': fs_uptime,
+            'freeswitch_calls': fs_calls,
+            'freeswitch_registrations': fs_registrations,
+            'freeswitch_gateway_statuses': '\n'.join(gateway_lines)
+            if gateway_lines else 'No active gateways',
+        })
 
     @api.model
     def get_webrtc_config(self):

--- a/connect_freeswitch/security/access_rules.xml
+++ b/connect_freeswitch/security/access_rules.xml
@@ -63,4 +63,35 @@
         <field name="perm_unlink" eval="False"/>
     </record>
 
+    <!-- connect.freeswitch.template access rules -->
+    <record id="access_freeswitch_template_admin" model="ir.model.access">
+        <field name="name">connect.freeswitch.template admin</field>
+        <field name="model_id" ref="model_connect_freeswitch_template"/>
+        <field name="group_id" ref="connect.group_admin"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+
+    <record id="access_freeswitch_template_user" model="ir.model.access">
+        <field name="name">connect.freeswitch.template user</field>
+        <field name="model_id" ref="model_connect_freeswitch_template"/>
+        <field name="group_id" ref="connect.group_user"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+
+    <record id="access_freeswitch_template_webhook" model="ir.model.access">
+        <field name="name">connect.freeswitch.template webhook</field>
+        <field name="model_id" ref="model_connect_freeswitch_template"/>
+        <field name="group_id" ref="connect.group_webhook"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+
 </odoo>

--- a/connect_freeswitch/views/fs_template_views.xml
+++ b/connect_freeswitch/views/fs_template_views.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_freeswitch_template_tree" model="ir.ui.view">
+        <field name="name">connect.freeswitch.template.tree</field>
+        <field name="model">connect.freeswitch.template</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="key"/>
+                <field name="name"/>
+                <field name="section"/>
+                <field name="is_customized"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="view_freeswitch_template_form" model="ir.ui.view">
+        <field name="name">connect.freeswitch.template.form</field>
+        <field name="model">connect.freeswitch.template</field>
+        <field name="arch" type="xml">
+            <form>
+                <header>
+                    <button name="reset_to_default" type="object"
+                            string="Reset to Default"
+                            class="btn-secondary"
+                            confirm="This will overwrite your customizations. Continue?"
+                            invisible="not is_customized"/>
+                </header>
+                <sheet>
+                    <div class="oe_title">
+                        <h1><field name="name"/></h1>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="key"/>
+                            <field name="section"/>
+                            <field name="is_customized"/>
+                        </group>
+                    </group>
+                    <group string="Available Variables">
+                        <field name="description" nolabel="1"/>
+                    </group>
+                    <notebook>
+                        <page string="Template" name="template">
+                            <field name="content" widget="code" options="{'mode': 'xml'}"/>
+                        </page>
+                        <page string="Default Template" name="default">
+                            <field name="default_content" widget="code" options="{'mode': 'xml'}"/>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_freeswitch_template" model="ir.actions.act_window">
+        <field name="name">XML Templates</field>
+        <field name="res_model">connect.freeswitch.template</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <menuitem id="menu_freeswitch_template"
+              name="XML Templates"
+              parent="connect.menu_connect_pbx"
+              action="action_freeswitch_template"
+              sequence="80"
+              groups="connect.group_admin"/>
+
+</odoo>

--- a/connect_freeswitch/views/settings.xml
+++ b/connect_freeswitch/views/settings.xml
@@ -9,6 +9,21 @@
             <page name="general" position="after">
                 <page name="freeswitch" string="FreeSWITCH">
                     <group>
+                        <group string="Status">
+                            <field name="freeswitch_status"/>
+                            <field name="freeswitch_uptime"/>
+                            <field name="freeswitch_calls"/>
+                            <field name="freeswitch_registrations"/>
+                            <button name="check_freeswitch_status" type="object"
+                                    string="CHECK STATUS" class="btn btn-info"
+                                    colspan="2"/>
+                        </group>
+                        <group string="Gateway Status">
+                            <field name="freeswitch_gateway_statuses"
+                                   nolabel="1" colspan="2"/>
+                        </group>
+                    </group>
+                    <group>
                         <group string="Connection">
                             <field name="freeswitch_socket_url"
                                    placeholder="wss://your-fs-domain:8082"/>

--- a/docs/admin/freeswitch-setup.md
+++ b/docs/admin/freeswitch-setup.md
@@ -234,6 +234,42 @@ All configuration files are in `deploy/freeswitch/conf/`. Key files:
 | `dialplan/default.xml` | Fallback dialplan (echo test, hold music test). |
 | `directory/default.xml` | User directory (delegates to Odoo via XML cURL). |
 
+## XML Templates
+
+Navigate to **Connect > PBX > XML Templates** to view and customize the FreeSWITCH XML configuration templates.
+
+Odoo generates FreeSWITCH XML dynamically using Jinja2 templates. Each template produces a specific piece of configuration — user directory entries, dialplan extensions, gateway definitions, etc. The system ships with sensible defaults, but administrators can customize any template to modify the generated XML.
+
+### Template List
+
+| Template | Section | Description |
+|----------|---------|-------------|
+| `directory_user` | Directory | Single user authentication entry |
+| `directory_full` | Directory | Full directory with all endpoints |
+| `dialplan_user_bridge` | Dialplan | Bridge call to user endpoints |
+| `dialplan_ivr` | Dialplan | IVR with digit collection and choices |
+| `dialplan_ring_group` | Dialplan | Ring group bridging to multiple users |
+| `dialplan_inbound_did` | Dialplan | Inbound DID routing |
+| `dialplan_outgoing_route` | Dialplan | Outbound call routing via gateway |
+| `dialplan_system` | Dialplan | System extensions (echo test) |
+| `config_sofia` | Configuration | Sofia SIP profile with gateways |
+| `config_sofia_gateway` | Configuration | Single SIP gateway element |
+| `config_xml_rpc` | Configuration | XML-RPC server settings |
+
+### Customizing Templates
+
+Each template form shows:
+
+- **Available Variables** — Documents the Jinja2 variables available for rendering
+- **Template** tab — The editable Jinja2 template (XML with `{{ variable }}` placeholders)
+- **Default Template** tab — The factory default for reference
+
+Templates use standard [Jinja2 syntax](https://jinja.palletsprojects.com/): `{{ variable }}` for values, `{% if %}` for conditionals, `{% for %}` for loops.
+
+### Reset to Default
+
+If a customized template causes issues, click **Reset to Default** in the form header to restore the factory default. Templates with customizations are marked with the **Customized** flag in the list view.
+
 ## XML cURL Integration
 
 FreeSWITCH fetches dynamic configuration from Odoo via HTTP:

--- a/specs/decisions/007-freeswitch-jinja2-templates.md
+++ b/specs/decisions/007-freeswitch-jinja2-templates.md
@@ -1,0 +1,49 @@
+# ADR-007: Replace ElementTree XML generation with Jinja2 templates
+
+**Status:** Accepted
+**Date:** 2026-03-18
+
+## Context
+
+FreeSWITCH XML configs (directory, dialplan, configuration) were generated programmatically using `xml.etree.ElementTree` (`ET.Element`/`ET.SubElement`) across 7 files (~580 lines). This approach had two problems:
+
+1. **Readability** — The Python code that builds XML trees is hard to read. You can't see the XML structure at a glance; it's buried in nested `ET.SubElement()` calls.
+2. **Customizability** — Administrators had no way to modify the generated XML without changing Python code.
+
+Jinja2 was already a project dependency (used for TwiML rendering in `connect_twilio`).
+
+## Decision
+
+Replace all ElementTree XML generation with Jinja2 templates stored in a new Odoo model `connect.freeswitch.template`.
+
+### Architecture
+
+**Two layers:**
+- **Envelope** (controller) — The `<document>/<section>` wrapper stays as simple string formatting in the controller. It's structural boilerplate that admins should not edit.
+- **Fragments** (templates) — The actual config content is stored as Jinja2 templates. Each template has a stable `key` for code lookup and an editable `content` field.
+
+**11 templates** covering directory (user, full), dialplan (user bridge, IVR, ring group, inbound DID, outgoing route, system), and configuration (sofia, gateway, xml_rpc).
+
+### Model design
+
+- `key` (unique, readonly) — stable identifier used in code
+- `content` — editable Jinja2 template
+- `default_content` — factory default for reset
+- `is_customized` — computed flag (content != default_content)
+- Templates seeded via `data/fs_templates.xml` with `noupdate="1"`
+
+### Rendering
+
+Template content is cached with `@tools.ormcache`. Uses `jinja2.StrictUndefined` to fail loudly on missing variables. Only `connect.group_admin` can edit templates.
+
+### Signature change
+
+Model methods changed from `generate_dialplan(self, context_el, params)` (mutating an ET parent) to `generate_dialplan(self, params)` (returning an XML string). The controller concatenates strings.
+
+## Consequences
+
+- XML templates are now readable — the actual XML structure is visible
+- Administrators can customize generated configs through the Odoo UI (PBX > XML Templates)
+- "Reset to Default" button allows recovery from broken customizations
+- Template cache avoids extra DB queries on every FreeSWITCH request
+- No ElementTree dependency in the XML generation path


### PR DESCRIPTION
## Summary

- Replace all ElementTree-based XML config generation in `connect_freeswitch` with Jinja2 templates stored in a new `connect.freeswitch.template` model (11 templates covering directory, dialplan, and configuration sections)
- Admins can customize generated FreeSWITCH XML configs through the Odoo UI (PBX > XML Templates) with "Reset to Default" support
- Add FreeSWITCH status panel to settings tab showing sofia profile and gateway status
- Add gateway name validation constraint (alphanumeric, hyphens, underscores, dots only)
- Extract TLS certificates from Traefik ACME storage at container startup for Verto WSS/DTLS-SRTP
- Add endpoints management directly on the user form

## Test plan

- [ ] Install/upgrade `connect_freeswitch` — verify 11 XML templates created
- [ ] Test directory XML generation (user lookup, full directory)
- [ ] Test dialplan generation (extension, IVR, ring group, inbound DID, outgoing route)
- [ ] Test sofia.conf and xml_rpc.conf configuration generation
- [ ] Edit a template in UI and verify customized XML output
- [ ] Test "Reset to Default" button restores factory content
- [ ] Verify FreeSWITCH status panel in settings tab
- [ ] Test gateway name validation rejects special characters
- [ ] Verify TLS cert extraction from Traefik ACME in Docker deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)