### PR TITLE
feat: auto-answer + WebRTC/SIP architecture refactoring

### DIFF
--- a/connect/__manifest__.py
+++ b/connect/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect',
-    'version': '19.0.1.0.0',
+    'version': '19.0.1.1.0',
     'category': 'Phone',
     'summary': 'Communication platform for Odoo',
     'depends': ['base', 'mail', 'contacts', 'sms'],

--- a/connect/models/endpoint.py
+++ b/connect/models/endpoint.py
@@ -6,5 +6,11 @@ class ConnectEndpoint(models.Model):
     _description = 'Connect Endpoint'
 
     name = fields.Char(string='Name', required=True)
-    connect_user_id = fields.Many2one('connect.user', string='Connect User', required=True, ondelete='cascade')
+    connect_user_id = fields.Many2one('connect.user', string='Connect User', ondelete='cascade')
+    exten = fields.Many2one('connect.exten', ondelete='set null', readonly=True)
+    exten_number = fields.Char(related='exten.number', store=True)
     active = fields.Boolean(default=True)
+
+    def create_extension(self):
+        self.ensure_one()
+        return self.env['connect.exten'].create_extension(self, 'endpoint')

--- a/connect/models/user.py
+++ b/connect/models/user.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from odoo import fields, models, api, release
 from odoo.exceptions import ValidationError
 if release.version_info[0] >= 19:
@@ -11,18 +10,17 @@ logger = logging.getLogger(__name__)
 
 class User(models.Model):
     _name = 'connect.user'
-    _rec_name = 'username'
+    _rec_name = 'name'
     _description = 'Connect User'
-    _order = 'username'
+    _order = 'name'
 
     callflow = fields.One2many('connect.user_callflow', 'user')
     endpoint_ids = fields.One2many('connect.endpoint', 'connect_user_id', string='Endpoints')
     endpoint_count = fields.Integer(compute='_compute_endpoint_count')
     exten = fields.Many2one('connect.exten', ondelete='set null', readonly=True)
     exten_number = fields.Char(related='exten.number', store=True)
-    name = fields.Char(compute='_get_name')
-    user = fields.Many2one('res.users', string='Odoo User', domain=[('share', '=', False)])
-    username = fields.Char(required=True)
+    name = fields.Char(compute='_get_name', store=True)
+    user = fields.Many2one('res.users', string='Odoo User', required=True, domain=[('share', '=', False)])
     record_calls = fields.Boolean(default=True)
     voicemail_enabled = fields.Boolean()
     voicemail_prompt = fields.Text(
@@ -36,26 +34,19 @@ class User(models.Model):
 
     if release.version_info[0] >= 19:
         _user_uniq = Constraint('UNIQUE("user")', 'This Odoo user account is already defined!')
-        _username_uniq = Constraint('UNIQUE(username)', 'This PBX username is already defined!')
     else:
         _sql_constraints = [
             ('user_uniq', 'UNIQUE("user")', 'This Odoo user account is already defined!'),
-            ('username_uniq', 'UNIQUE(username)', 'This PBX username is already defined!'),
         ]
 
     def _compute_endpoint_count(self):
         for rec in self:
             rec.endpoint_count = len(rec.endpoint_ids)
 
+    @api.depends('user', 'user.name')
     def _get_name(self):
         for rec in self:
-            rec.name = rec.user.name if rec.user else rec.username
-
-    @api.constrains('username')
-    def _check_username(self):
-        for rec in self:
-            if not rec.username.isalnum():
-                raise ValidationError('Username must be alphanumeric!')
+            rec.name = rec.user.name if rec.user else ''
 
     def manage_group(self, action='add'):
         attribute_name = 'user_ids' if release.version_info[0] >= 19 else 'users'
@@ -98,8 +89,6 @@ class User(models.Model):
     def write(self, vals):
         if 'user' in vals.keys():
             self.manage_group('remove')
-        if 'username' in vals:
-            raise ValidationError('Username cannot be changed!')
         res = super().write(vals)
         self.manage_group()
         if res and not self.env.context.get('no_clear_cache'):
@@ -121,15 +110,7 @@ class User(models.Model):
 
     @api.model
     def get_user_by_uri(self, userinfo):
-        if not userinfo:
-            return self.env['connect.user']
-        re_call_uri = re.compile(r'^(?:sip|client):([^@]+)@')
-        found_username = re_call_uri.search(userinfo)
-        if found_username:
-            user = self.env['connect.user'].search([
-                ('username', '=', found_username.group(1))])
-            debug(self, 'Found user: {} by {}.'.format(user.username, userinfo))
-            return user
+        """Lookup connect.user by SIP/client URI. No-op in core; overridden by provider modules."""
         return self.env['connect.user']
 
     def create_extension(self):

--- a/connect/views/call_views.xml
+++ b/connect/views/call_views.xml
@@ -41,8 +41,8 @@
                         <group string="Call Info">
                             <field name="direction"/>
                             <field name="call_type"/>
-                            <field name="caller"/>
-                            <field name="called"/>
+                            <field name="caller" widget="phone"/>
+                            <field name="called" widget="phone"/>
                             <field name="partner"/>
                             <field name="duration_human" string="Duration"/>
                         </group>

--- a/connect/views/callflow_views.xml
+++ b/connect/views/callflow_views.xml
@@ -66,8 +66,8 @@
                         <page name="ring_users" string="Ring Users">
                             <field name="ring_users">
                                 <list>
-                                    <field name="username"/>
                                     <field name="user"/>
+                                    <field name="exten"/>
                                 </list>
                             </field>
                         </page>

--- a/connect/views/endpoint_views.xml
+++ b/connect/views/endpoint_views.xml
@@ -7,6 +7,7 @@
             <list>
                 <field name="name"/>
                 <field name="connect_user_id"/>
+                <field name="exten" invisible="connect_user_id"/>
             </list>
         </field>
     </record>
@@ -16,6 +17,10 @@
         <field name="model">connect.endpoint</field>
         <field name="arch" type="xml">
             <form>
+                <header>
+                    <button name="create_extension" type="object" string="Extension"
+                            class="btn btn-primary" invisible="connect_user_id"/>
+                </header>
                 <sheet>
                     <div class="oe_title">
                         <label for="name"/>
@@ -24,9 +29,12 @@
                         </h1>
                         <label for="connect_user_id"/>
                         <h2>
-                            <field name="connect_user_id" placeholder="Odoo Account"/>
+                            <field name="connect_user_id" placeholder="Connect User"/>
                         </h2>
                     </div>
+                    <group invisible="connect_user_id">
+                        <field name="exten" readonly="1"/>
+                    </group>
                 </sheet>
             </form>
         </field>
@@ -40,6 +48,7 @@
                 <field name="name"/>
                 <field name="connect_user_id"/>
                 <separator/>
+                <filter string="Standalone" name="standalone" domain="[('connect_user_id', '=', False)]"/>
                 <filter string="Archived" name="archived" domain="[('active', '=', False)]"/>
             </search>
         </field>

--- a/connect/views/user_views.xml
+++ b/connect/views/user_views.xml
@@ -5,7 +5,6 @@
         <field name="model">connect.user</field>
         <field name="arch" type="xml">
             <list>
-                <field name="username"/>
                 <field name="user"/>
                 <field name="exten" optional="show"/>
                 <field name="outgoing_callerid" optional="show"/>
@@ -29,7 +28,6 @@
                     <div class="oe_button_box" name="button_box"/>
                     <group>
                         <group string="User Info">
-                            <field name="username"/>
                             <field name="user"/>
                             <field name="exten" readonly="1"/>
                             <field name="outgoing_callerid"/>

--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.2.2',
+    'version': '19.0.1.3.0',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',
     'depends': ['connect', 'web'],

--- a/connect_freeswitch/controllers/freeswitch_xml.py
+++ b/connect_freeswitch/controllers/freeswitch_xml.py
@@ -72,67 +72,155 @@ class FreeSwitchXMLController(http.Controller):
         return self._get_full_directory(domain)
 
     def _get_user_xml(self, user, domain, params):
-        """Generate XML for a specific user."""
+        """Generate XML for a specific user.
+
+        Lookup order:
+        1. SIP endpoint by auth_user (SIP registration)
+        2. WebRTC user by res.users login (Verto registration)
+        3. User by exten_number (bridge to user)
+        4. Standalone endpoint by exten_number (bridge to endpoint)
+        """
         Endpoint = request.env['connect.endpoint'].sudo()
         ConnectUser = request.env['connect.user'].sudo()
-
-        # 1. Search by auth_user (for registration/login)
-        endpoint = Endpoint.search([
-            ('auth_user', '=', user),
-            ('active', '=', True),
-            '|', ('sip_enabled', '=', True), ('webrtc_enabled', '=', True)
-        ], limit=1)
-
-        # 2. If not found, search by exten_number (for incoming call/bridge)
-        if not endpoint:
-            connect_user = ConnectUser.search([
-                ('exten_number', '=', user),
-                ('active', '=', True)
-            ], limit=1)
-            if connect_user:
-                # Get the first active endpoint for this user
-                endpoint = Endpoint.search([
-                    ('connect_user_id', '=', connect_user.id),
-                    ('active', '=', True),
-                    '|', ('sip_enabled', '=', True), ('webrtc_enabled', '=', True)
-                ], limit=1)
-
-        if not endpoint:
-            debug(request.env['connect.settings'].sudo(), "User not found in Odoo: %s" % user)
-            return self._not_found()
-
-        connect_user = endpoint.connect_user_id
-
-        # CRITICAL: FS expects the XML ID to match the requested 'user'
-        # If '1000' was requested, return '1000' even if the endpoint is 'admin'
-        xml_user_id = user
 
         fs_domain = request.env['connect.settings'].sudo().get_param('freeswitch_domain')
         actual_domain = fs_domain or domain or params.get('sip_auth_realm', '')
 
-        # Build dial-string so that bridge(user/1000) works
+        # 1. Search by auth_user (SIP endpoint registration)
+        endpoint = Endpoint.search([
+            ('auth_user', '=', user),
+            ('active', '=', True),
+        ], limit=1)
+
+        if endpoint:
+            return self._directory_for_endpoint(endpoint, user, actual_domain)
+
+        # 2. Search by res.users login (Verto WebRTC registration)
+        connect_user = ConnectUser.search([
+            ('user.login', '=', user),
+            ('webrtc_enabled', '=', True),
+            ('active', '=', True),
+        ], limit=1)
+        if connect_user:
+            return self._directory_for_webrtc_user(connect_user, user, actual_domain)
+
+        # 3. Search by exten_number (bridge to user)
+        connect_user = ConnectUser.search([
+            ('exten_number', '=', user),
+            ('active', '=', True),
+        ], limit=1)
+        if connect_user:
+            return self._directory_for_user_bridge(connect_user, user, actual_domain)
+
+        # 4. Search standalone endpoint by exten_number (bridge to endpoint)
+        endpoint = Endpoint.search([
+            ('exten_number', '=', user),
+            ('connect_user_id', '=', False),
+            ('active', '=', True),
+        ], limit=1)
+        if endpoint:
+            return self._directory_for_endpoint(endpoint, user, actual_domain)
+
+        debug(request.env['connect.settings'].sudo(), "User not found in Odoo: %s" % user)
+        return self._not_found()
+
+    def _directory_for_endpoint(self, endpoint, xml_user_id, domain):
+        """Directory entry for a SIP endpoint (registration or bridge)."""
+        connect_user = endpoint.connect_user_id
+
+        # Dial-string for this endpoint only (SIP contact)
+        dial_string = "${{sofia_contact(*/{auth_user}@{domain})}}".format(
+            auth_user=endpoint.auth_user, domain=domain)
+
+        cid_name = connect_user.name if connect_user else endpoint.auth_user
+        cid_num = (connect_user.exten_number if connect_user else endpoint.exten_number) or endpoint.auth_user
+
+        return self._render_directory_user(
+            xml_user_id=xml_user_id,
+            password=endpoint.auth_password or '',
+            dial_string=dial_string,
+            cid_name=cid_name,
+            cid_num=cid_num,
+            connect_user_id=str(connect_user.id) if connect_user else '',
+            endpoint_id=str(endpoint.id),
+            odoo_user_id=str(connect_user.user.id) if connect_user and connect_user.user else '',
+            domain=domain,
+        )
+
+    def _directory_for_webrtc_user(self, connect_user, xml_user_id, domain):
+        """Directory entry for a WebRTC/Verto user registration."""
+        dial_string = "${{verto_contact({user_id}@{domain})}}".format(
+            user_id=xml_user_id, domain=domain)
+
+        cid_name = connect_user.name
+        cid_num = connect_user.exten_number or xml_user_id
+
+        return self._render_directory_user(
+            xml_user_id=xml_user_id,
+            password=connect_user.webrtc_password or '',
+            dial_string=dial_string,
+            cid_name=cid_name,
+            cid_num=cid_num,
+            connect_user_id=str(connect_user.id),
+            endpoint_id='',
+            odoo_user_id=str(connect_user.user.id) if connect_user.user else '',
+            domain=domain,
+        )
+
+    def _directory_for_user_bridge(self, connect_user, xml_user_id, domain):
+        """Directory entry for bridging to a user (combined dial-string)."""
         dial_parts = []
-        if endpoint.sip_enabled and endpoint.sip_ring:
+
+        # All active SIP endpoints (incoming calls ring all, not just originate_ring)
+        endpoints = request.env['connect.endpoint'].sudo().search([
+            ('connect_user_id', '=', connect_user.id),
+            ('active', '=', True),
+            ('auth_user', '!=', False),
+        ])
+        for ep in endpoints:
             dial_parts.append("${{sofia_contact(*/{auth_user}@{domain})}}".format(
-                auth_user=endpoint.auth_user, domain=actual_domain))
-        if endpoint.webrtc_enabled and endpoint.webrtc_ring:
+                auth_user=ep.auth_user, domain=domain))
+
+        # WebRTC contact
+        if connect_user.webrtc_enabled:
+            verto_login = connect_user.user.login
             dial_parts.append("${{verto_contact({user_id}@{domain})}}".format(
-                user_id=xml_user_id, domain=actual_domain))
+                user_id=verto_login, domain=domain))
+
         dial_string = ",".join(dial_parts)
 
-        cid_name = connect_user.name or endpoint.auth_user
-        cid_num = connect_user.exten_number or endpoint.auth_user
+        cid_name = connect_user.name
+        cid_num = connect_user.exten_number or (endpoints[0].auth_user if endpoints else '')
 
+        # Password: use webrtc_password or first endpoint's password (needed for FS XML structure)
+        password = connect_user.webrtc_password or (endpoints[0].auth_password if endpoints else '') or ''
+
+        return self._render_directory_user(
+            xml_user_id=xml_user_id,
+            password=password,
+            dial_string=dial_string,
+            cid_name=cid_name,
+            cid_num=cid_num,
+            connect_user_id=str(connect_user.id),
+            endpoint_id=str(endpoints[0].id) if endpoints else '',
+            odoo_user_id=str(connect_user.user.id) if connect_user.user else '',
+            domain=domain,
+        )
+
+    def _render_directory_user(self, xml_user_id, password, dial_string,
+                                cid_name, cid_num, connect_user_id,
+                                endpoint_id, odoo_user_id, domain):
+        """Render directory user XML from template."""
         Template = request.env['connect.freeswitch.template'].sudo()
         user_xml = Template.render('directory_user', {
             'xml_user_id': xml_user_id,
-            'password': endpoint.auth_password or '',
+            'password': password,
             'dial_string': dial_string,
             'cid_name': cid_name,
             'cid_num': cid_num,
-            'connect_user_id': str(connect_user.id),
-            'endpoint_id': str(endpoint.id),
-            'odoo_user_id': str(connect_user.user.id) if connect_user.user else '',
+            'connect_user_id': connect_user_id,
+            'endpoint_id': endpoint_id,
+            'odoo_user_id': odoo_user_id,
         })
 
         xml_str = ('<document type="freeswitch/xml">'
@@ -140,37 +228,55 @@ class FreeSwitchXMLController(http.Controller):
                    '<domain name="{domain}">'
                    '{body}'
                    '</domain></section></document>').format(
-                       domain=actual_domain, body=user_xml)
+                       domain=domain, body=user_xml)
         return self._xml_response_str(xml_str)
 
     def _get_full_directory(self, domain):
         """Generate full directory XML with all users."""
         Endpoint = request.env['connect.endpoint'].sudo()
-
-        endpoints = Endpoint.search([
-            ('active', '=', True),
-            ('auth_user', '!=', False),
-            ('auth_password', '!=', False),
-            '|', ('sip_enabled', '=', True), ('webrtc_enabled', '=', True)
-        ])
-
-        if not endpoints:
-            return self._not_found()
+        ConnectUser = request.env['connect.user'].sudo()
 
         actual_domain = request.env['connect.settings'].sudo().get_param('freeswitch_domain') or domain
 
         ep_data = []
+
+        # All active SIP endpoints
+        endpoints = Endpoint.search([
+            ('active', '=', True),
+            ('auth_user', '!=', False),
+            ('auth_password', '!=', False),
+        ])
         for endpoint in endpoints:
             connect_user = endpoint.connect_user_id
             ep_data.append({
                 'auth_user': endpoint.auth_user,
                 'password': endpoint.auth_password,
-                'cid_name': connect_user.name or endpoint.auth_user,
-                'cid_num': connect_user.exten_number or endpoint.auth_user,
-                'connect_user_id': str(connect_user.id),
+                'cid_name': connect_user.name if connect_user else endpoint.auth_user,
+                'cid_num': (connect_user.exten_number if connect_user else endpoint.exten_number) or endpoint.auth_user,
+                'connect_user_id': str(connect_user.id) if connect_user else '',
                 'endpoint_id': str(endpoint.id),
-                'odoo_user_id': str(connect_user.user.id) if connect_user.user else '',
+                'odoo_user_id': str(connect_user.user.id) if connect_user and connect_user.user else '',
             })
+
+        # All active WebRTC users
+        webrtc_users = ConnectUser.search([
+            ('webrtc_enabled', '=', True),
+            ('webrtc_password', '!=', False),
+            ('active', '=', True),
+        ])
+        for wu in webrtc_users:
+            ep_data.append({
+                'auth_user': wu.user.login,
+                'password': wu.webrtc_password,
+                'cid_name': wu.name,
+                'cid_num': wu.exten_number or wu.user.login,
+                'connect_user_id': str(wu.id),
+                'endpoint_id': '',
+                'odoo_user_id': str(wu.user.id) if wu.user else '',
+            })
+
+        if not ep_data:
+            return self._not_found()
 
         Template = request.env['connect.freeswitch.template'].sudo()
         body = Template.render('directory_full', {'endpoints': ep_data})
@@ -235,7 +341,6 @@ class FreeSwitchXMLController(http.Controller):
     def _route_internal(self, destination, params):
         """Route internal calls: extensions, outgoing routes, system extensions."""
         Exten = request.env['connect.exten'].sudo()
-        ConnectUser = request.env['connect.user'].sudo()
 
         parts = []
 
@@ -247,15 +352,6 @@ class FreeSwitchXMLController(http.Controller):
         exten = Exten.search([('number', '=', destination)], limit=1)
         if exten:
             parts.append(exten.generate_dialplan(params))
-            return ''.join(parts)
-
-        # Try user by username (handles transfers that use username instead of extension)
-        connect_user = ConnectUser.search([
-            ('username', '=', destination),
-            ('active', '=', True)
-        ], limit=1)
-        if connect_user:
-            parts.append(connect_user.generate_dialplan(params))
             return ''.join(parts)
 
         # Try regex pattern match against all extensions

--- a/connect_freeswitch/controllers/freeswitch_xml.py
+++ b/connect_freeswitch/controllers/freeswitch_xml.py
@@ -93,6 +93,12 @@ class FreeSwitchXMLController(http.Controller):
         ], limit=1)
 
         if endpoint:
+            # For bridge requests (not SIP auth), if the endpoint belongs to
+            # a user, return the combined dial-string (all endpoints + WebRTC)
+            action = params.get('action', '')
+            if action != 'sip_auth' and endpoint.connect_user_id:
+                return self._directory_for_user_bridge(
+                    endpoint.connect_user_id, user, actual_domain)
             return self._directory_for_endpoint(endpoint, user, actual_domain)
 
         # 2. Search by res.users login (Verto WebRTC registration)

--- a/connect_freeswitch/controllers/webrtc.py
+++ b/connect_freeswitch/controllers/webrtc.py
@@ -13,28 +13,20 @@ class WebRTCController(http.Controller):
     def get_webrtc_config(self):
         """
         Get WebRTC configuration for the current user.
-        Returns endpoint credentials and FreeSWITCH socket URL if user has
-        a connect.user record with a WebRTC-enabled endpoint.
+        Returns credentials and FreeSWITCH socket URL if user has
+        a connect.user record with WebRTC enabled.
         """
         user = request.env.user
-        
+
         connect_user = request.env['connect.user'].search([
             ('user', '=', user.id),
-            ('active', '=', True)
-        ], limit=1)
-        
-        if not connect_user:
-            return {'enabled': False, 'reason': 'no_connect_user'}
-        
-        endpoint = request.env['connect.endpoint'].search([
-            ('connect_user_id', '=', connect_user.id),
             ('webrtc_enabled', '=', True),
             ('active', '=', True)
         ], limit=1)
-        
-        if not endpoint:
-            return {'enabled': False, 'reason': 'no_webrtc_endpoint'}
-        
+
+        if not connect_user:
+            return {'enabled': False, 'reason': 'no_webrtc_user'}
+
         socket_url = request.env['connect.settings'].get_param('freeswitch_socket_url')
         domain = request.env['connect.settings'].get_param('freeswitch_domain')
 
@@ -45,8 +37,8 @@ class WebRTCController(http.Controller):
             'enabled': True,
             'socketUrl': socket_url,
             'domain': domain,
-            'login': endpoint.auth_user,
-            'password': endpoint.auth_password,
+            'login': user.login,
+            'password': connect_user.webrtc_password,
             'callerName': connect_user.name,
-            'callerNumber': connect_user.exten_number or endpoint.auth_user,
+            'callerNumber': connect_user.exten_number or user.login,
         }

--- a/connect_freeswitch/migrations/19.0.1.3.0/post-migrate.py
+++ b/connect_freeswitch/migrations/19.0.1.3.0/post-migrate.py
@@ -1,0 +1,46 @@
+"""Migrate WebRTC settings from endpoint to user level.
+
+In 19.0.1.3.0, WebRTC fields (webrtc_enabled, webrtc_ring) moved from
+connect.endpoint to connect.user. This script copies existing WebRTC
+settings to the corresponding connect.user records.
+"""
+import logging
+import secrets
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    # Check if the old columns still exist
+    cr.execute("""
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'connect_endpoint' AND column_name = 'webrtc_enabled'
+    """)
+    if not cr.fetchone():
+        _logger.info("Column webrtc_enabled not found on connect_endpoint, skipping migration")
+        return
+
+    # Find endpoints with WebRTC enabled and copy settings to their user
+    cr.execute("""
+        SELECT DISTINCT e.connect_user_id, e.webrtc_ring
+        FROM connect_endpoint e
+        WHERE e.webrtc_enabled = true
+          AND e.connect_user_id IS NOT NULL
+    """)
+    rows = cr.fetchall()
+
+    for connect_user_id, webrtc_ring in rows:
+        webrtc_password = secrets.token_urlsafe(16)
+        cr.execute("""
+            UPDATE connect_user
+            SET webrtc_enabled = true,
+                originate_ring = %s,
+                webrtc_password = %s
+            WHERE id = %s
+        """, (webrtc_ring if webrtc_ring is not None else True,
+              webrtc_password, connect_user_id))
+
+    _logger.info("Migrated WebRTC settings for %d users", len(rows))

--- a/connect_freeswitch/models/call.py
+++ b/connect_freeswitch/models/call.py
@@ -74,6 +74,10 @@ class Call(models.Model):
         # Build a-leg (user's ringable endpoints + WebRTC)
         a_leg_parts = []
 
+        # Display target number/partner on user's phone (a-leg caller ID)
+        display_name = caller_name or number
+        display_number = number
+
         # SIP endpoints with originate_ring enabled
         endpoints = self.env['connect.endpoint'].search([
             ('connect_user_id', '=', connect_user.id),
@@ -82,7 +86,12 @@ class Call(models.Model):
             ('auth_user', '!=', False),
         ])
         for ep in endpoints:
-            leg_vars = ['leg_timeout=30']
+            leg_vars = [
+                'leg_timeout=30',
+                "origination_caller_id_name='{}'".format(
+                    display_name.replace("'", "")),
+                'origination_caller_id_number={}'.format(display_number),
+            ]
             if ep.auto_answer_header:
                 # Parse header: "Alert-Info:answer-after=0" → sip_h_Alert-Info=answer-after=0
                 header_name, _, header_value = ep.auto_answer_header.partition(':')
@@ -96,15 +105,20 @@ class Call(models.Model):
         if connect_user.webrtc_enabled and connect_user.originate_ring:
             verto_login = connect_user.user.login
             a_leg_parts.append(
-                '[leg_timeout=30,auto_answer=true]user/{}@{}'.format(
-                    verto_login, domain))
+                "[leg_timeout=30,origination_caller_id_name='{name}'"
+                ",origination_caller_id_number={num}"
+                ",verto_h_auto_answer=true]user/{login}@{domain}".format(
+                    name=display_name.replace("'", ""),
+                    num=display_number,
+                    login=verto_login,
+                    domain=domain))
 
         if not a_leg_parts:
             raise UserError("You don't have any ringable endpoints configured.")
 
         a_leg = ','.join(a_leg_parts)
 
-        # Caller ID
+        # Caller ID for b-leg (what the called party sees)
         first_ep = endpoints[:1]
         caller_number = connect_user.exten_number or (first_ep.auth_user if first_ep else '')
 

--- a/connect_freeswitch/models/call.py
+++ b/connect_freeswitch/models/call.py
@@ -71,56 +71,49 @@ class Call(models.Model):
         if not connect_user:
             raise UserError("You don't have a Connect user configured.")
 
+        # Build a-leg (user's ringable endpoints + WebRTC)
+        a_leg_parts = []
+
+        # SIP endpoints with originate_ring enabled
         endpoints = self.env['connect.endpoint'].search([
             ('connect_user_id', '=', connect_user.id),
             ('active', '=', True),
+            ('originate_ring', '=', True),
+            ('auth_user', '!=', False),
         ])
-        # Filter to ringable endpoints (SIP with ring, or WebRTC with ring)
-        ring_endpoints = endpoints.filtered(
-            lambda ep: (ep.sip_enabled and ep.sip_ring)
-            or (ep.webrtc_enabled and ep.webrtc_ring)
-        )
-        if not ring_endpoints:
+        for ep in endpoints:
+            leg_vars = ['leg_timeout=30']
+            if ep.auto_answer_header:
+                # Parse header: "Alert-Info:answer-after=0" → sip_h_Alert-Info=answer-after=0
+                header_name, _, header_value = ep.auto_answer_header.partition(':')
+                if header_name and header_value:
+                    leg_vars.append('sip_h_{}={}'.format(
+                        header_name.strip(), header_value.strip()))
+            a_leg_parts.append(
+                '[{}]user/{}@{}'.format(','.join(leg_vars), ep.auth_user, domain))
+
+        # WebRTC (Verto) leg from user
+        if connect_user.webrtc_enabled and connect_user.originate_ring:
+            verto_login = connect_user.user.login
+            a_leg_parts.append(
+                '[leg_timeout=30,auto_answer=true]user/{}@{}'.format(
+                    verto_login, domain))
+
+        if not a_leg_parts:
             raise UserError("You don't have any ringable endpoints configured.")
 
-        # Build a-leg (user's endpoints)
-        a_leg_parts = []
-        for ep in ring_endpoints:
-            a_leg_parts.append(
-                '[leg_timeout=30]user/{}@{}'.format(
-                    ep.auth_user, domain))
         a_leg = ','.join(a_leg_parts)
 
         # Caller ID
-        caller_number = connect_user.exten_number or ring_endpoints[0].auth_user
+        first_ep = endpoints[:1]
+        caller_number = connect_user.exten_number or (first_ep.auth_user if first_ep else '')
 
         # Check if target is an internal extension
         exten = self.env['connect.exten'].search(
             [('number', '=', number)], limit=1)
         if exten:
-            # Internal call — bridge to extension's endpoints
-            target_user = self.env['connect.user'].search([
-                ('exten', '=', exten.id),
-                ('active', '=', True),
-            ], limit=1)
-            if target_user:
-                target_endpoints = self.env['connect.endpoint'].search([
-                    ('connect_user_id', '=', target_user.id),
-                    ('active', '=', True),
-                ]).filtered(
-                    lambda ep: (ep.sip_enabled and ep.sip_ring)
-                    or (ep.webrtc_enabled and ep.webrtc_ring)
-                )
-                if target_endpoints:
-                    b_parts = []
-                    for ep in target_endpoints:
-                        b_parts.append(
-                            'user/{}@{}'.format(ep.auth_user, domain))
-                    b_leg = ','.join(b_parts)
-                else:
-                    b_leg = 'user/{}@{}'.format(number, domain)
-            else:
-                b_leg = 'user/{}@{}'.format(number, domain)
+            # Internal call — bridge to extension's destination
+            b_leg = self._build_internal_b_leg(exten, domain)
         else:
             # External call — find outgoing route
             routes = self.env['connect.freeswitch.outgoing_route'].sudo().search(
@@ -164,6 +157,48 @@ class Call(models.Model):
                 "Failed to originate call: {}".format(result or 'no response'))
 
         return True
+
+    def _build_internal_b_leg(self, exten, domain):
+        """Build b-leg bridge string for an internal extension."""
+        # Check if extension points to a user
+        if exten.model == 'connect.user' and exten.res_id:
+            target_user = self.env['connect.user'].browse(exten.res_id)
+            if target_user.exists() and target_user.active:
+                return self._build_user_bridge(target_user, domain)
+
+        # Check if extension points to a standalone endpoint
+        if exten.model == 'connect.endpoint' and exten.res_id:
+            target_ep = self.env['connect.endpoint'].browse(exten.res_id)
+            if target_ep.exists() and target_ep.active and target_ep.auth_user:
+                return 'user/{}@{}'.format(target_ep.auth_user, domain)
+
+        # Fallback: bridge to the extension number directly
+        return 'user/{}@{}'.format(exten.number, domain)
+
+    def _build_user_bridge(self, target_user, domain):
+        """Build bridge string for all of a user's active contacts."""
+        b_parts = []
+
+        # SIP endpoints (all active, not just originate_ring)
+        target_endpoints = self.env['connect.endpoint'].search([
+            ('connect_user_id', '=', target_user.id),
+            ('active', '=', True),
+            ('auth_user', '!=', False),
+        ])
+        for ep in target_endpoints:
+            b_parts.append('user/{}@{}'.format(ep.auth_user, domain))
+
+        # WebRTC
+        if target_user.webrtc_enabled:
+            b_parts.append('user/{}@{}'.format(
+                target_user.user.login, domain))
+
+        if b_parts:
+            return ','.join(b_parts)
+
+        # Fallback
+        return 'user/{}@{}'.format(
+            target_user.exten_number or '', domain)
 
     @api.model
     def on_freeswitch_cdr(self, cdr_data):

--- a/connect_freeswitch/models/endpoint.py
+++ b/connect_freeswitch/models/endpoint.py
@@ -3,15 +3,49 @@ from odoo import fields, models, api
 from odoo.exceptions import ValidationError
 
 
+AUTO_ANSWER_HEADERS = [
+    ('Alert-Info:answer-after=0', 'Alert-Info:answer-after=0'),
+    ('Alert-Info: Info=Alert-Autoanswer', 'Alert-Info: Info=Alert-Autoanswer'),
+    ('Alert-Info: Info=Auto Answer', 'Alert-Info: Info=Auto Answer'),
+    ('Alert-Info: ;info=alert-autoanswer', 'Alert-Info: ;info=alert-autoanswer'),
+    ('Alert-Info: <sip:>;info=alert-autoanswer', 'Alert-Info: <sip:>;info=alert-autoanswer'),
+    ('Alert-Info: Ring Answer', 'Alert-Info: Ring Answer'),
+    ('Answer-Mode: Auto', 'Answer-Mode: Auto'),
+    ('Call Info: Answer-After=0', 'Call Info: Answer-After=0'),
+    ('Call-Info: Auto Answer', 'Call-Info: Auto Answer'),
+    ('Call-Info: <sip:>;answer-after=0', 'Call-Info: <sip:>;answer-after=0'),
+    ('P-Auto-Answer: normal', 'P-Auto-Answer: normal'),
+]
+
+
 class ConnectEndpoint(models.Model):
     _inherit = 'connect.endpoint'
 
     auth_user = fields.Char(string='Auth User')
     auth_password = fields.Char(string='Auth Password')
-    sip_enabled = fields.Boolean(string='SIP Enabled', default=False)
-    sip_ring = fields.Boolean(string='SIP Ring', default=True)
-    webrtc_enabled = fields.Boolean(string='WebRTC Enabled', default=False)
-    webrtc_ring = fields.Boolean(string='WebRTC Ring', default=True)
+    originate_ring = fields.Boolean(string='Originate Ring', default=True,
+        help='Include this endpoint when originating click-to-call calls.')
+    auto_answer_header = fields.Selection(
+        selection=AUTO_ANSWER_HEADERS,
+        string='Auto-Answer Header',
+        help='SIP header sent to auto-answer the phone during click-to-call originate.')
+
+    def generate_dialplan(self, params, exten=None):
+        """Generate FreeSWITCH dialplan to bridge to this standalone endpoint."""
+        self.ensure_one()
+        number = exten.number if exten else self.exten_number or self.auth_user
+        if not number:
+            return ''
+        fs_domain = self.env['connect.settings'].sudo().get_param('freeswitch_domain') or '${domain}'
+
+        return self.env['connect.freeswitch.template'].render('dialplan_user_bridge', {
+            'number': re.escape(number),
+            'user_id': self.connect_user_id.id if self.connect_user_id else 0,
+            'exten_id': exten.id if exten else None,
+            'record_calls': False,
+            'recording_url': '',
+            'fs_domain': fs_domain,
+        })
 
     @api.constrains('auth_user')
     def _check_auth_user(self):

--- a/connect_freeswitch/models/exten.py
+++ b/connect_freeswitch/models/exten.py
@@ -1,12 +1,16 @@
 import logging
 import re
-from odoo import models
+from odoo import fields, models
 
 logger = logging.getLogger(__name__)
 
 
 class Exten(models.Model):
     _inherit = 'connect.exten'
+
+    dst = fields.Reference(
+        selection_add=[('connect.endpoint', 'Endpoint')],
+    )
 
     def generate_dialplan(self, params):
         """Generate FreeSWITCH dialplan XML for this extension."""

--- a/connect_freeswitch/models/fs_callflow.py
+++ b/connect_freeswitch/models/fs_callflow.py
@@ -46,7 +46,7 @@ class CallFlow(models.Model):
                 continue
             dst = choice.exten.dst
             if dst and dst._name == 'connect.user':
-                user_number = dst.exten_number or dst.username
+                user_number = dst.exten_number
                 choices.append({
                     'digits_escaped': re.escape(choice.choice_digits),
                     'dst_type': 'user',
@@ -88,12 +88,9 @@ class CallFlow(models.Model):
 
         bridge_parts = []
         for user in self.ring_users:
-            endpoint = self.env['connect.endpoint'].sudo().search([
-                ('connect_user_id', '=', user.id),
-                ('active', '=', True),
-                '|', ('sip_enabled', '=', True), ('webrtc_enabled', '=', True)
-            ], limit=1)
-            user_number = user.exten_number or user.username
+            user_number = user.exten_number
+            if not user_number:
+                continue
             bridge_parts.append('user/{}@{}'.format(user_number, fs_domain))
 
         return self.env['connect.freeswitch.template'].render('dialplan_ring_group', {

--- a/connect_freeswitch/models/fs_user.py
+++ b/connect_freeswitch/models/fs_user.py
@@ -1,6 +1,7 @@
 import logging
 import re
-from odoo import models
+import secrets
+from odoo import models, fields, api
 
 logger = logging.getLogger(__name__)
 
@@ -8,10 +9,32 @@ logger = logging.getLogger(__name__)
 class User(models.Model):
     _inherit = 'connect.user'
 
+    webrtc_enabled = fields.Boolean(string='WebRTC Enabled', default=False)
+    originate_ring = fields.Boolean(string='Originate Ring', default=True,
+        help='Include WebRTC client when originating click-to-call calls.')
+    webrtc_password = fields.Char(string='WebRTC Password', readonly=True)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get('webrtc_enabled') and not vals.get('webrtc_password'):
+                vals['webrtc_password'] = secrets.token_urlsafe(16)
+        return super().create(vals_list)
+
+    def write(self, vals):
+        if vals.get('webrtc_enabled'):
+            for rec in self:
+                if not rec.webrtc_password and not vals.get('webrtc_password'):
+                    vals['webrtc_password'] = secrets.token_urlsafe(16)
+                    break
+        return super().write(vals)
+
     def generate_dialplan(self, params, exten=None):
         """Generate FreeSWITCH dialplan to bridge to this user's endpoints."""
         self.ensure_one()
-        number = exten.number if exten else self.exten_number or self.username
+        number = exten.number if exten else self.exten_number
+        if not number:
+            return ''
         base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url') or ''
 
         recording_url = ''

--- a/connect_freeswitch/models/number.py
+++ b/connect_freeswitch/models/number.py
@@ -14,7 +14,7 @@ class Number(models.Model):
 
         transfer_target = ''
         if self.destination == 'user' and self.user:
-            transfer_target = self.user.exten_number or self.user.username
+            transfer_target = self.user.exten_number
         elif self.destination == 'callflow' and self.callflow:
             transfer_target = self.callflow.exten_number or str(self.callflow.id)
 

--- a/connect_freeswitch/models/settings.py
+++ b/connect_freeswitch/models/settings.py
@@ -199,27 +199,19 @@ class Settings(models.Model):
     def get_webrtc_config(self):
         """
         Get WebRTC configuration for the current user.
-        Returns endpoint credentials and FreeSWITCH socket URL if user has
-        a connect.user record with a WebRTC-enabled endpoint.
+        Returns credentials and FreeSWITCH socket URL if user has
+        a connect.user record with WebRTC enabled.
         """
         user = self.env.user
 
         connect_user = self.env['connect.user'].search([
             ('user', '=', user.id),
-            ('active', '=', True)
-        ], limit=1)
-
-        if not connect_user:
-            return {'enabled': False, 'reason': 'no_connect_user'}
-
-        endpoint = self.env['connect.endpoint'].search([
-            ('connect_user_id', '=', connect_user.id),
             ('webrtc_enabled', '=', True),
             ('active', '=', True)
         ], limit=1)
 
-        if not endpoint:
-            return {'enabled': False, 'reason': 'no_webrtc_endpoint'}
+        if not connect_user:
+            return {'enabled': False, 'reason': 'no_webrtc_user'}
 
         socket_url = self.get_param('freeswitch_socket_url')
         domain = self.get_param('freeswitch_domain')
@@ -231,8 +223,8 @@ class Settings(models.Model):
             'enabled': True,
             'socketUrl': socket_url,
             'domain': domain,
-            'login': endpoint.auth_user,
-            'password': endpoint.auth_password,
+            'login': user.login,
+            'password': connect_user.webrtc_password,
             'callerName': connect_user.name,
-            'callerNumber': connect_user.exten_number or endpoint.auth_user,
+            'callerNumber': connect_user.exten_number or user.login,
         }

--- a/connect_freeswitch/static/src/js/phone_systray.js
+++ b/connect_freeswitch/static/src/js/phone_systray.js
@@ -159,6 +159,10 @@ export class PhoneSystray extends Component {
         });
 
         this.vertoClient = null;
+        this._ringAudioCtx = null;
+        this._ringOscillator = null;
+        this._ringGain = null;
+        this._ringInterval = null;
 
         onWillStart(async () => {
             await this.loadConfig();
@@ -172,6 +176,7 @@ export class PhoneSystray extends Component {
 
         onWillUnmount(() => {
             this.disconnect();
+            this._stopRingtone();
         });
     }
 
@@ -207,12 +212,16 @@ export class PhoneSystray extends Component {
                     this.state.showDialpad = true;
                     this.state.callerName = data.callerName || "";
                     this.state.callerNumber = data.callerNumber || "";
-                } else if (state === "idle") {
-                    this.state.callerName = "";
-                    this.state.callerNumber = "";
-                } else if (data.callerName || data.callerNumber) {
-                    if (data.callerName) this.state.callerName = data.callerName;
-                    if (data.callerNumber) this.state.callerNumber = data.callerNumber;
+                    this._startRingtone();
+                } else {
+                    this._stopRingtone();
+                    if (state === "idle") {
+                        this.state.callerName = "";
+                        this.state.callerNumber = "";
+                    } else if (data.callerName || data.callerNumber) {
+                        if (data.callerName) this.state.callerName = data.callerName;
+                        if (data.callerNumber) this.state.callerNumber = data.callerNumber;
+                    }
                 }
             },
             onError: (error) => {
@@ -244,6 +253,51 @@ export class PhoneSystray extends Component {
 
     closeDialpad() {
         this.state.showDialpad = false;
+    }
+
+    _startRingtone() {
+        this._stopRingtone();
+        try {
+            this._ringAudioCtx = new AudioContext();
+            this._ringGain = this._ringAudioCtx.createGain();
+            this._ringGain.connect(this._ringAudioCtx.destination);
+            this._ringGain.gain.value = 0;
+
+            this._ringOscillator = this._ringAudioCtx.createOscillator();
+            this._ringOscillator.type = "sine";
+            this._ringOscillator.frequency.value = 440;
+            this._ringOscillator.connect(this._ringGain);
+            this._ringOscillator.start();
+
+            // Ring pattern: 1s on, 2s off
+            this._ringing = true;
+            const ringCycle = () => {
+                if (!this._ringing) return;
+                this._ringGain.gain.value = 0.3;
+                this._ringTimeout = setTimeout(() => {
+                    if (!this._ringing) return;
+                    this._ringGain.gain.value = 0;
+                    this._ringTimeout = setTimeout(ringCycle, 2000);
+                }, 1000);
+            };
+            ringCycle();
+        } catch (error) {
+            console.error("[Phone] Failed to start ringtone:", error);
+        }
+    }
+
+    _stopRingtone() {
+        this._ringing = false;
+        clearTimeout(this._ringTimeout);
+        if (this._ringOscillator) {
+            try { this._ringOscillator.stop(); } catch {}
+            this._ringOscillator = null;
+        }
+        if (this._ringAudioCtx) {
+            this._ringAudioCtx.close();
+            this._ringAudioCtx = null;
+        }
+        this._ringGain = null;
     }
 
     getIconClass() {

--- a/connect_freeswitch/static/src/js/verto_client.js
+++ b/connect_freeswitch/static/src/js/verto_client.js
@@ -529,6 +529,18 @@ export class VertoClient {
             incoming: true
         };
 
+        // Auto-answer if the channel variable is set (click-to-call originate)
+        const autoAnswer = dp.auto_answer || params.auto_answer;
+        if (autoAnswer === 'true' || autoAnswer === true) {
+            console.log('[Verto] Auto-answering call (click-to-call)');
+            try {
+                await this.answer();
+                return;
+            } catch (error) {
+                console.error('[Verto] Auto-answer failed:', error);
+            }
+        }
+
         this._setCallState('incoming', { callerName, callerNumber });
     }
 

--- a/connect_freeswitch/static/src/js/verto_client.js
+++ b/connect_freeswitch/static/src/js/verto_client.js
@@ -530,7 +530,9 @@ export class VertoClient {
         };
 
         // Auto-answer if the channel variable is set (click-to-call originate)
-        const autoAnswer = dp.auto_answer || params.auto_answer;
+        // mod_verto passes verto_h_* channel vars in params or pvt
+        const pvt = params.pvt || {};
+        const autoAnswer = dp.auto_answer || params.auto_answer || pvt.auto_answer;
         if (autoAnswer === 'true' || autoAnswer === true) {
             console.log('[Verto] Auto-answering call (click-to-call)');
             try {

--- a/connect_freeswitch/static/src/js/verto_client.js
+++ b/connect_freeswitch/static/src/js/verto_client.js
@@ -530,9 +530,8 @@ export class VertoClient {
         };
 
         // Auto-answer if the channel variable is set (click-to-call originate)
-        // mod_verto passes verto_h_* channel vars in params or pvt
-        const pvt = params.pvt || {};
-        const autoAnswer = dp.auto_answer || params.auto_answer || pvt.auto_answer;
+        // mod_verto passes verto_h_* vars flat in params with prefix preserved
+        const autoAnswer = params.verto_h_auto_answer;
         if (autoAnswer === 'true' || autoAnswer === true) {
             console.log('[Verto] Auto-answering call (click-to-call)');
             try {

--- a/connect_freeswitch/views/endpoint_views.xml
+++ b/connect_freeswitch/views/endpoint_views.xml
@@ -6,10 +6,9 @@
         <field name="inherit_id" ref="connect.view_connect_endpoint_tree"/>
         <field name="arch" type="xml">
             <field name="connect_user_id" position="after">
-                <field name="sip_enabled"/>
-                <field name="sip_ring" invisible="not sip_enabled"/>
-                <field name="webrtc_enabled"/>
-                <field name="webrtc_ring" invisible="not webrtc_enabled"/>
+                <field name="auth_user"/>
+                <field name="originate_ring" invisible="not connect_user_id"/>
+                <field name="auto_answer_header" optional="hide" invisible="not connect_user_id"/>
             </field>
         </field>
     </record>
@@ -20,8 +19,7 @@
         <field name="inherit_id" ref="connect.view_connect_endpoint_search"/>
         <field name="arch" type="xml">
             <filter name="archived" position="before">
-                <filter string="SIP Enabled" name="sip_enabled" domain="[('sip_enabled', '=', True)]"/>
-                <filter string="WebRTC Enabled" name="webrtc_enabled" domain="[('webrtc_enabled', '=', True)]"/>
+                <filter string="Originate Ring" name="originate_ring" domain="[('originate_ring', '=', True)]"/>
                 <separator/>
             </filter>
         </field>
@@ -33,19 +31,13 @@
         <field name="inherit_id" ref="connect.view_connect_endpoint_form"/>
         <field name="arch" type="xml">
             <div class="oe_title" position="after">
-                <group>
-                    <group string="SIP">
-                        <field name="sip_enabled" widget="boolean_toggle"/>
-                        <field name="sip_ring" widget="boolean_toggle" invisible="not sip_enabled"/>
-                    </group>
-                    <group string="WebRTC">
-                        <field name="webrtc_enabled" widget="boolean_toggle"/>
-                        <field name="webrtc_ring" widget="boolean_toggle" invisible="not webrtc_enabled"/>
-                    </group>
-                </group>
-                <group string="Authentication" invisible="not sip_enabled and not webrtc_enabled">
+                <group string="Authentication">
                     <field name="auth_user"/>
                     <field name="auth_password" password="True"/>
+                </group>
+                <group string="Click-to-Call" invisible="not connect_user_id">
+                    <field name="originate_ring" widget="boolean_toggle"/>
+                    <field name="auto_answer_header" invisible="not originate_ring"/>
                 </group>
             </div>
         </field>

--- a/connect_freeswitch/views/user_views.xml
+++ b/connect_freeswitch/views/user_views.xml
@@ -13,16 +13,23 @@
                 </button>
             </div>
             <notebook position="inside">
+                <page name="webrtc" string="WebRTC">
+                    <group>
+                        <group>
+                            <field name="webrtc_enabled" widget="boolean_toggle"/>
+                            <field name="originate_ring" widget="boolean_toggle"
+                                   invisible="not webrtc_enabled"/>
+                        </group>
+                    </group>
+                </page>
                 <page name="endpoints" string="Endpoints">
                     <field name="endpoint_ids">
                         <list editable="bottom">
                             <field name="name"/>
-                            <field name="sip_enabled"/>
-                            <field name="sip_ring" invisible="not sip_enabled"/>
-                            <field name="webrtc_enabled"/>
-                            <field name="webrtc_ring" invisible="not webrtc_enabled"/>
-                            <field name="auth_user" invisible="not sip_enabled and not webrtc_enabled"/>
-                            <field name="auth_password" password="True" invisible="not sip_enabled and not webrtc_enabled"/>
+                            <field name="auth_user"/>
+                            <field name="auth_password" password="True"/>
+                            <field name="originate_ring"/>
+                            <field name="auto_answer_header" optional="hide"/>
                             <field name="active" column_invisible="1"/>
                         </list>
                     </field>

--- a/connect_twilio/__manifest__.py
+++ b/connect_twilio/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect Twilio',
-    'version': '19.0.1.0.0',
+    'version': '19.0.1.1.0',
     'category': 'Phone',
     'summary': 'Twilio integration for Oduist Connect',
     'depends': ['connect'],

--- a/connect_twilio/models/user.py
+++ b/connect_twilio/models/user.py
@@ -8,6 +8,8 @@ from urllib.parse import urljoin
 
 from odoo import fields, models, api, release
 from odoo.exceptions import ValidationError
+if release.version_info[0] >= 19:
+    from odoo.models import Constraint
 from twilio.jwt.access_token import AccessToken
 from twilio.jwt.access_token.grants import VoiceGrant
 from twilio.twiml.voice_response import Client, Dial, VoiceResponse
@@ -24,6 +26,36 @@ SIP_TWILIO_EDGES.insert(0, ['roaming', 'Global Low-latency Roaming'])
 
 class User(models.Model):
     _inherit = 'connect.user'
+
+    username = fields.Char(required=True)
+
+    if release.version_info[0] >= 19:
+        _username_uniq = Constraint('UNIQUE(username)', 'This PBX username is already defined!')
+    else:
+        _sql_constraints = [
+            ('username_uniq', 'UNIQUE(username)', 'This PBX username is already defined!'),
+        ]
+
+    @api.constrains('username')
+    def _check_username(self):
+        for rec in self:
+            if rec.username and not rec.username.isalnum():
+                raise ValidationError('Username must be alphanumeric!')
+
+    @api.model
+    def get_user_by_uri(self, userinfo):
+        """Lookup connect.user by SIP/client URI using username."""
+        if not userinfo:
+            return self.env['connect.user']
+        re_call_uri = re.compile(r'^(?:sip|client):([^@]+)@')
+        found_username = re_call_uri.search(userinfo)
+        if found_username:
+            user = self.env['connect.user'].search([
+                ('username', '=', found_username.group(1))])
+            if user:
+                debug(self, 'Found user: {} by {}.'.format(user.name, userinfo))
+            return user
+        return self.env['connect.user']
 
     sid = fields.Char('SID', readonly=True)
     password = fields.Char(

--- a/connect_twilio/views/user_views.xml
+++ b/connect_twilio/views/user_views.xml
@@ -7,6 +7,9 @@
         <field name="model">connect.user</field>
         <field name="inherit_id" ref="connect.view_connect_user_tree"/>
         <field name="arch" type="xml">
+            <xpath expr="//field[@name='user']" position="after">
+                <field name="username"/>
+            </xpath>
             <xpath expr="//field[@name='outgoing_callerid']" position="after">
                 <field name="sip_enabled" string="SIP"/>
                 <field name="client_enabled" string="Web"/>
@@ -22,7 +25,10 @@
         <field name="model">connect.user</field>
         <field name="inherit_id" ref="connect.view_connect_user_form"/>
         <field name="arch" type="xml">
-            <!-- Add domain and twilio_edge to User Info group -->
+            <!-- Add username and domain to User Info group -->
+            <xpath expr="//field[@name='user']" position="after">
+                <field name="username"/>
+            </xpath>
             <xpath expr="//field[@name='active']" position="after">
                 <field name="domain"/>
                 <field name="twilio_edge"

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -162,9 +162,11 @@ connect.settings (singleton)
     |       |       |
     |       |       +-- connect.user_callflow_call
     |       |
-    |       +-- connect.endpoint
+    |       +-- connect.endpoint (optional link)
     |       |
     |       +-- connect.exten (extension routing)
+    |
+    +-- connect.endpoint (can also be standalone, without user)
     |
     +-- connect.callflow (IVR)
     |       |

--- a/specs/connect_core.md
+++ b/specs/connect_core.md
@@ -298,16 +298,15 @@ Order: `id desc`
 
 ### 6. user.py - `connect.user`
 
-Rec name: `username`
-Order: `username`
+Rec name: `name`
+Order: `name`
 
 **Fields:**
 
 | Field | Type | Notes |
 |-------|------|-------|
-| `name` | Char | Computed from user/username |
-| `username` | Char | Required, alphanumeric |
-| `user` | Many2one | `res.users` |
+| `name` | Char | Computed (stored) from `user.name` |
+| `user` | Many2one | `res.users`, Required |
 | `exten` | Many2one | `connect.exten`, readonly |
 | `exten_number` | Char | Related to exten |
 | `callflow` | One2many | `connect.user_callflow` |
@@ -322,17 +321,15 @@ Order: `username`
 
 **Constraints:**
 - `UNIQUE(user)` - one connect.user per res.users
-- `UNIQUE(username)` - unique username
 
 **Methods:**
 
 | Method | Description |
 |--------|-------------|
-| `_get_name()` | Compute name from linked res.users or username |
-| `_check_username()` | Constrains: alphanumeric only |
+| `_get_name()` | Compute name from linked res.users |
 | `manage_group()` | Add/remove security groups on linked res.users |
 | `get_user_by_exten_number()` | Lookup connect.user by extension number |
-| `get_user_by_uri()` | Lookup connect.user by SIP URI or client identity |
+| `get_user_by_uri()` | No-op in core (returns empty recordset). Integration modules override to lookup connect.user by SIP URI or client identity. |
 | `create_extension()` | Create associated `connect.exten` record |
 | `render_voicemail_prompt()` | Render Jinja2 voicemail template with call context |
 | `get_greeting_message()` | Return greeting (override point for integrations) |
@@ -367,13 +364,22 @@ Order: `username`
 
 ### 8. endpoint.py - `connect.endpoint`
 
-Keep as-is from current module.
-
 | Field | Type | Notes |
 |-------|------|-------|
 | `name` | Char | Required |
-| `connect_user_id` | Many2one | `connect.user` |
+| `connect_user_id` | Many2one | `connect.user`, optional |
+| `exten` | Many2one | `connect.exten` |
+| `exten_number` | Char | Related to `exten.number` |
 | `active` | Boolean | |
+
+**Methods:**
+
+| Method | Description |
+|--------|-------------|
+| `create_extension()` | Create associated `connect.exten` record for this endpoint |
+
+**Notes:**
+- `connect_user_id` is optional to support standalone endpoints (e.g., conference room phones, lobby phones) that are not associated with a specific user.
 
 ---
 

--- a/specs/decisions/010-autoanswer-webrtc-refactor.md
+++ b/specs/decisions/010-autoanswer-webrtc-refactor.md
@@ -1,0 +1,42 @@
+# 010 — Auto-Answer Headers + WebRTC/SIP Architecture Refactoring
+
+## Problem
+
+1. Click-to-call (ADR 009) requires the user to manually answer their own phone (a-leg) before the target number rings. SIP phones support auto-answer via vendor-specific SIP headers. Verto clients can auto-answer programmatically.
+
+2. The current architecture puts both SIP and WebRTC config on `connect.endpoint`, but an Odoo user can only have one WebRTC phone (browser-based Verto client). SIP endpoints can exist independently of Odoo users (e.g., lobby phones, conference rooms).
+
+## Decision
+
+### WebRTC moves to `connect.user`, SIP stays on `connect.endpoint`
+
+- `connect.user` gains `webrtc_enabled`, `originate_ring`, and auto-generated `webrtc_password`
+- Verto login uses `res.users.login` (email) — no separate username needed
+- `connect.endpoint` becomes purely SIP: `auth_user`, `auth_password`, `originate_ring`, `auto_answer_header`
+- `sip_enabled` removed — all endpoints are SIP by definition
+- `sip_ring` renamed to `originate_ring` — controls click-to-call participation only; incoming calls ring all endpoints
+
+### Standalone SIP endpoints
+
+- `connect.endpoint.connect_user_id` becomes optional
+- Endpoints without a user get their own `exten` (extension number) for routing
+- Endpoints with a user inherit the user's exten
+
+### `username` moves to `connect_twilio`
+
+- Core `connect.user` no longer has `username` — it was only used for Twilio SIP domain registration
+- `connect.user.user` (res.users) becomes required
+- `get_user_by_uri()` becomes a no-op in core; `connect_twilio` overrides it
+
+### Auto-answer for click-to-call
+
+- SIP: configurable `auto_answer_header` Selection field on endpoint (vendor-specific SIP headers like `Alert-Info`, `Call-Info`, `Answer-Mode`, etc.)
+- Verto: `auto_answer=true` channel variable on the Verto leg; JS client checks and auto-answers
+
+## Consequences
+
+- FreeSWITCH directory XML must serve separate entries for SIP endpoints and WebRTC users
+- `originate_call()` builds a-leg from user's SIP endpoints (filtered by `originate_ring`) + WebRTC (if enabled and `originate_ring`)
+- Dial-string for incoming calls includes ALL active endpoints + WebRTC (not filtered by `originate_ring`)
+- Standalone endpoints need their own extension to be reachable
+- Migration script copies existing endpoint WebRTC settings to user level


### PR DESCRIPTION
## Summary

- Move WebRTC config from `connect.endpoint` to `connect.user` — an Odoo user can only have one browser-based Verto client. Endpoints become purely SIP with optional user assignment, enabling standalone SIP phones.
- Add `auto_answer_header` Selection field on endpoints for SIP auto-answer, and `verto_h_auto_answer` channel variable for Verto auto-answer during click-to-call originate.
- Move `username` field from core to `connect_twilio` (only used for Twilio SIP domain registration). Core `connect.user` now requires `res.users` and uses stored computed `name` as `_rec_name`.
- Rewrite FreeSWITCH XML directory controller with 4-step lookup: SIP endpoint → WebRTC user → user bridge → standalone endpoint. Click-to-call a-leg now displays target number/partner name instead of user's own extension.
- Includes migration script, ADR 010, updated specs, and phone widget on call form caller/called fields.

## Test plan

- [x] Create user with WebRTC enabled → verify password auto-generated on save
- [x] Click-to-call → Verto auto-answers, shows target number on phone display
- [x] SIP endpoint with auto-answer header → phone auto-answers on originate
- [x] Create standalone endpoint (no user) with own extension → receives inbound calls
- [x] Inbound call to user extension → rings all SIP endpoints + WebRTC
- [x] Verify FreeSWITCH directory XML serves both SIP and WebRTC entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)