### PR TITLE
feat(freeswitch): configurable phone display mode (dropdown vs float)

### DIFF
--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.3.0',
+    'version': '19.0.1.4.0',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',
     'depends': ['connect', 'web'],
@@ -19,6 +19,8 @@
             'connect_freeswitch/static/src/css/phone_systray.css',
             'connect_freeswitch/static/src/js/verto_client.js',
             'connect_freeswitch/static/src/js/phone_systray.js',
+            'connect_freeswitch/static/src/js/phone_panel.js',
+            'connect_freeswitch/static/src/js/phone_service.js',
             'connect_freeswitch/static/src/xml/phone_systray.xml',
             'connect_freeswitch/static/src/widgets/phone_field/*',
         ],

--- a/connect_freeswitch/models/fs_user.py
+++ b/connect_freeswitch/models/fs_user.py
@@ -12,6 +12,11 @@ class User(models.Model):
     webrtc_enabled = fields.Boolean(string='WebRTC Enabled', default=False)
     originate_ring = fields.Boolean(string='Originate Ring', default=True,
         help='Include WebRTC client when originating click-to-call calls.')
+    phone_display_mode = fields.Selection(
+        [('dropdown', 'Dropdown'), ('float', 'Floating Panel')],
+        string='Phone Display',
+        default='dropdown',
+    )
     webrtc_password = fields.Char(string='WebRTC Password', readonly=True)
 
     @api.model_create_multi

--- a/connect_freeswitch/models/settings.py
+++ b/connect_freeswitch/models/settings.py
@@ -227,4 +227,5 @@ class Settings(models.Model):
             'password': connect_user.webrtc_password,
             'callerName': connect_user.name,
             'callerNumber': connect_user.exten_number or user.login,
+            'displayMode': connect_user.phone_display_mode or 'dropdown',
         }

--- a/connect_freeswitch/static/src/css/phone_systray.css
+++ b/connect_freeswitch/static/src/css/phone_systray.css
@@ -2,7 +2,7 @@
     position: relative;
 }
 
-/* Dropdown mode: positioned top-right near systray, with overlay */
+/* Dropdown mode: anchored below the systray icon, with overlay */
 .o_phone_mode_dropdown .o_phone_dialpad_overlay {
     position: fixed;
     top: 0;
@@ -14,8 +14,6 @@
 
 .o_phone_mode_dropdown .o_phone_dialpad {
     position: fixed;
-    top: 50px;
-    right: 16px;
     z-index: 1051;
 }
 

--- a/connect_freeswitch/static/src/css/phone_systray.css
+++ b/connect_freeswitch/static/src/css/phone_systray.css
@@ -2,7 +2,8 @@
     position: relative;
 }
 
-.o_phone_dialpad_overlay {
+/* Dropdown mode: positioned top-right near systray, with overlay */
+.o_phone_mode_dropdown .o_phone_dialpad_overlay {
     position: fixed;
     top: 0;
     left: 0;
@@ -11,16 +12,36 @@
     z-index: 1050;
 }
 
+.o_phone_mode_dropdown .o_phone_dialpad {
+    position: fixed;
+    top: 50px;
+    right: 16px;
+    z-index: 1051;
+}
+
+/* Float mode: positioned bottom-left, no overlay */
+.o_phone_mode_float {
+    position: fixed;
+    bottom: 16px;
+    left: 16px;
+    z-index: 1100;
+}
+
+.o_phone_mode_float .o_phone_dialpad_overlay {
+    display: none;
+}
+
+.o_phone_mode_float .o_phone_dialpad {
+    position: static;
+}
+
+/* Shared dialpad styles */
 .o_phone_dialpad {
-    position: absolute;
-    top: 100%;
-    right: 0;
     width: 280px;
     background: white;
     border: 1px solid #dee2e6;
     border-radius: 8px;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
-    z-index: 1051;
     padding: 15px;
 }
 

--- a/connect_freeswitch/static/src/css/phone_systray.css
+++ b/connect_freeswitch/static/src/css/phone_systray.css
@@ -2,7 +2,7 @@
     position: relative;
 }
 
-/* Dropdown mode: anchored below the systray icon, with overlay */
+/* Dropdown mode: positioned top-right near systray, with overlay */
 .o_phone_mode_dropdown .o_phone_dialpad_overlay {
     position: fixed;
     top: 0;
@@ -14,6 +14,8 @@
 
 .o_phone_mode_dropdown .o_phone_dialpad {
     position: fixed;
+    top: 50px;
+    right: 16px;
     z-index: 1051;
 }
 

--- a/connect_freeswitch/static/src/js/phone_panel.js
+++ b/connect_freeswitch/static/src/js/phone_panel.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { Component, useState, onMounted, onWillUnmount } from "@odoo/owl";
+import { Component, useState, useRef, onMounted, onWillUnmount } from "@odoo/owl";
 import { PhoneDialpad } from "./phone_systray";
 
 
@@ -15,6 +15,8 @@ export class PhonePanel extends Component {
     };
 
     setup() {
+        this.panelRef = useRef("panelRef");
+
         this.state = useState({
             showDialpad: false,
             vertoState: "disconnected",
@@ -22,6 +24,8 @@ export class PhonePanel extends Component {
             callerName: "",
             callerNumber: "",
         });
+
+        this._anchorRect = null;
 
         this._onStateChanged = ({ detail }) => {
             this.state.vertoState = detail.vertoState;
@@ -42,6 +46,10 @@ export class PhonePanel extends Component {
             } else {
                 this.state.showDialpad = !this.state.showDialpad;
             }
+            if (detail && detail.anchorRect) {
+                this._anchorRect = detail.anchorRect;
+            }
+            this._updateDropdownPosition();
         };
         this._onClose = () => {
             this.state.showDialpad = false;
@@ -66,6 +74,19 @@ export class PhonePanel extends Component {
             this.props.bus.removeEventListener("phoneToggle", this._onToggle);
             this.props.bus.removeEventListener("phoneClose", this._onClose);
             this.props.bus.removeEventListener("phoneNavigated", this._onNavigated);
+        });
+    }
+
+    _updateDropdownPosition() {
+        if (this.props.displayMode !== "dropdown" || !this.state.showDialpad) return;
+
+        requestAnimationFrame(() => {
+            const dialpad = this.panelRef.el?.querySelector(".o_phone_dialpad");
+            if (!dialpad || !this._anchorRect) return;
+
+            const rect = this._anchorRect;
+            dialpad.style.top = `${rect.bottom}px`;
+            dialpad.style.right = `${window.innerWidth - rect.right}px`;
         });
     }
 

--- a/connect_freeswitch/static/src/js/phone_panel.js
+++ b/connect_freeswitch/static/src/js/phone_panel.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { Component, useState, useRef, onMounted, onWillUnmount } from "@odoo/owl";
+import { Component, useState, onMounted, onWillUnmount } from "@odoo/owl";
 import { PhoneDialpad } from "./phone_systray";
 
 
@@ -15,8 +15,6 @@ export class PhonePanel extends Component {
     };
 
     setup() {
-        this.panelRef = useRef("panelRef");
-
         this.state = useState({
             showDialpad: false,
             vertoState: "disconnected",
@@ -24,8 +22,6 @@ export class PhonePanel extends Component {
             callerName: "",
             callerNumber: "",
         });
-
-        this._anchorRect = null;
 
         this._onStateChanged = ({ detail }) => {
             this.state.vertoState = detail.vertoState;
@@ -46,10 +42,6 @@ export class PhonePanel extends Component {
             } else {
                 this.state.showDialpad = !this.state.showDialpad;
             }
-            if (detail && detail.anchorRect) {
-                this._anchorRect = detail.anchorRect;
-            }
-            this._updateDropdownPosition();
         };
         this._onClose = () => {
             this.state.showDialpad = false;
@@ -74,19 +66,6 @@ export class PhonePanel extends Component {
             this.props.bus.removeEventListener("phoneToggle", this._onToggle);
             this.props.bus.removeEventListener("phoneClose", this._onClose);
             this.props.bus.removeEventListener("phoneNavigated", this._onNavigated);
-        });
-    }
-
-    _updateDropdownPosition() {
-        if (this.props.displayMode !== "dropdown" || !this.state.showDialpad) return;
-
-        requestAnimationFrame(() => {
-            const dialpad = this.panelRef.el?.querySelector(".o_phone_dialpad");
-            if (!dialpad || !this._anchorRect) return;
-
-            const rect = this._anchorRect;
-            dialpad.style.top = `${rect.bottom}px`;
-            dialpad.style.right = `${window.innerWidth - rect.right}px`;
         });
     }
 

--- a/connect_freeswitch/static/src/js/phone_panel.js
+++ b/connect_freeswitch/static/src/js/phone_panel.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { Component, useState, useRef, onMounted, onWillUnmount } from "@odoo/owl";
+import { Component, useState, onMounted, onWillUnmount } from "@odoo/owl";
 import { PhoneDialpad } from "./phone_systray";
 
 
@@ -15,8 +15,6 @@ export class PhonePanel extends Component {
     };
 
     setup() {
-        this.panelRef = useRef("panelRef");
-
         this.state = useState({
             showDialpad: false,
             vertoState: "disconnected",
@@ -24,8 +22,6 @@ export class PhonePanel extends Component {
             callerName: "",
             callerNumber: "",
         });
-
-        this._anchorRect = null;
 
         this._onStateChanged = ({ detail }) => {
             this.state.vertoState = detail.vertoState;
@@ -46,10 +42,6 @@ export class PhonePanel extends Component {
             } else {
                 this.state.showDialpad = !this.state.showDialpad;
             }
-            if (detail && detail.anchorRect) {
-                this._anchorRect = detail.anchorRect;
-            }
-            this._updateDropdownPosition();
         };
         this._onClose = () => {
             this.state.showDialpad = false;
@@ -74,20 +66,6 @@ export class PhonePanel extends Component {
             this.props.bus.removeEventListener("phoneToggle", this._onToggle);
             this.props.bus.removeEventListener("phoneClose", this._onClose);
             this.props.bus.removeEventListener("phoneNavigated", this._onNavigated);
-        });
-    }
-
-    _updateDropdownPosition() {
-        if (this.props.displayMode !== "dropdown" || !this.state.showDialpad) return;
-
-        // Wait for the DOM to render, then position the dialpad
-        requestAnimationFrame(() => {
-            const dialpad = this.panelRef.el?.querySelector(".o_phone_dialpad");
-            if (!dialpad || !this._anchorRect) return;
-
-            const rect = this._anchorRect;
-            dialpad.style.top = `${rect.bottom}px`;
-            dialpad.style.right = `${window.innerWidth - rect.right}px`;
         });
     }
 

--- a/connect_freeswitch/static/src/js/phone_panel.js
+++ b/connect_freeswitch/static/src/js/phone_panel.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { Component, useState, onMounted, onWillUnmount } from "@odoo/owl";
+import { Component, useState, useRef, onMounted, onWillUnmount } from "@odoo/owl";
 import { PhoneDialpad } from "./phone_systray";
 
 
@@ -15,6 +15,8 @@ export class PhonePanel extends Component {
     };
 
     setup() {
+        this.panelRef = useRef("panelRef");
+
         this.state = useState({
             showDialpad: false,
             vertoState: "disconnected",
@@ -22,6 +24,8 @@ export class PhonePanel extends Component {
             callerName: "",
             callerNumber: "",
         });
+
+        this._anchorRect = null;
 
         this._onStateChanged = ({ detail }) => {
             this.state.vertoState = detail.vertoState;
@@ -42,6 +46,10 @@ export class PhonePanel extends Component {
             } else {
                 this.state.showDialpad = !this.state.showDialpad;
             }
+            if (detail && detail.anchorRect) {
+                this._anchorRect = detail.anchorRect;
+            }
+            this._updateDropdownPosition();
         };
         this._onClose = () => {
             this.state.showDialpad = false;
@@ -66,6 +74,20 @@ export class PhonePanel extends Component {
             this.props.bus.removeEventListener("phoneToggle", this._onToggle);
             this.props.bus.removeEventListener("phoneClose", this._onClose);
             this.props.bus.removeEventListener("phoneNavigated", this._onNavigated);
+        });
+    }
+
+    _updateDropdownPosition() {
+        if (this.props.displayMode !== "dropdown" || !this.state.showDialpad) return;
+
+        // Wait for the DOM to render, then position the dialpad
+        requestAnimationFrame(() => {
+            const dialpad = this.panelRef.el?.querySelector(".o_phone_dialpad");
+            if (!dialpad || !this._anchorRect) return;
+
+            const rect = this._anchorRect;
+            dialpad.style.top = `${rect.bottom}px`;
+            dialpad.style.right = `${window.innerWidth - rect.right}px`;
         });
     }
 

--- a/connect_freeswitch/static/src/js/phone_panel.js
+++ b/connect_freeswitch/static/src/js/phone_panel.js
@@ -1,0 +1,79 @@
+/** @odoo-module **/
+
+import { Component, useState, onMounted, onWillUnmount } from "@odoo/owl";
+import { PhoneDialpad } from "./phone_systray";
+
+
+export class PhonePanel extends Component {
+    static template = "connect_freeswitch.PhonePanel";
+    static components = { PhoneDialpad };
+    static props = {
+        bus: Object,
+        displayMode: String,
+        getVertoClient: Function,
+        connect: Function,
+    };
+
+    setup() {
+        this.state = useState({
+            showDialpad: false,
+            vertoState: "disconnected",
+            callState: "idle",
+            callerName: "",
+            callerNumber: "",
+        });
+
+        this._onStateChanged = ({ detail }) => {
+            this.state.vertoState = detail.vertoState;
+        };
+        this._onCallStateChanged = ({ detail }) => {
+            this.state.callState = detail.callState;
+            if (detail.callState === "idle") {
+                this.state.callerName = "";
+                this.state.callerNumber = "";
+            } else {
+                if (detail.callerName) this.state.callerName = detail.callerName;
+                if (detail.callerNumber) this.state.callerNumber = detail.callerNumber;
+            }
+        };
+        this._onToggle = ({ detail }) => {
+            if (detail && detail.show !== undefined) {
+                this.state.showDialpad = detail.show;
+            } else {
+                this.state.showDialpad = !this.state.showDialpad;
+            }
+        };
+        this._onClose = () => {
+            this.state.showDialpad = false;
+        };
+        this._onNavigated = () => {
+            if (this.props.displayMode === "dropdown") {
+                this.state.showDialpad = false;
+            }
+        };
+
+        onMounted(() => {
+            this.props.bus.addEventListener("phoneStateChanged", this._onStateChanged);
+            this.props.bus.addEventListener("phoneCallStateChanged", this._onCallStateChanged);
+            this.props.bus.addEventListener("phoneToggle", this._onToggle);
+            this.props.bus.addEventListener("phoneClose", this._onClose);
+            this.props.bus.addEventListener("phoneNavigated", this._onNavigated);
+        });
+
+        onWillUnmount(() => {
+            this.props.bus.removeEventListener("phoneStateChanged", this._onStateChanged);
+            this.props.bus.removeEventListener("phoneCallStateChanged", this._onCallStateChanged);
+            this.props.bus.removeEventListener("phoneToggle", this._onToggle);
+            this.props.bus.removeEventListener("phoneClose", this._onClose);
+            this.props.bus.removeEventListener("phoneNavigated", this._onNavigated);
+        });
+    }
+
+    get modeClass() {
+        return this.props.displayMode === "float" ? "o_phone_mode_float" : "o_phone_mode_dropdown";
+    }
+
+    closeDialpad() {
+        this.state.showDialpad = false;
+    }
+}

--- a/connect_freeswitch/static/src/js/phone_service.js
+++ b/connect_freeswitch/static/src/js/phone_service.js
@@ -11,6 +11,11 @@ export const phoneService = {
     dependencies: ["orm"],
 
     async start(env, { orm }) {
+        const pathname = document.location.pathname;
+        if (!pathname.includes("/odoo")) {
+            return { enabled: false };
+        }
+
         let config;
         try {
             config = await orm.call("connect.settings", "get_webrtc_config", []);

--- a/connect_freeswitch/static/src/js/phone_service.js
+++ b/connect_freeswitch/static/src/js/phone_service.js
@@ -11,11 +11,6 @@ export const phoneService = {
     dependencies: ["orm"],
 
     async start(env, { orm }) {
-        const pathname = document.location.pathname;
-        if (!pathname.includes("/odoo")) {
-            return { enabled: false };
-        }
-
         let config;
         try {
             config = await orm.call("connect.settings", "get_webrtc_config", []);

--- a/connect_freeswitch/static/src/js/phone_service.js
+++ b/connect_freeswitch/static/src/js/phone_service.js
@@ -1,0 +1,157 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { EventBus } from "@odoo/owl";
+import { PhoneSystray } from "./phone_systray";
+import { PhonePanel } from "./phone_panel";
+import { VertoClient } from "./verto_client";
+
+
+export const phoneService = {
+    dependencies: ["orm"],
+
+    async start(env, { orm }) {
+        const pathname = document.location.pathname;
+        if (!pathname.includes("/odoo")) {
+            return { enabled: false };
+        }
+
+        let config;
+        try {
+            config = await orm.call("connect.settings", "get_webrtc_config", []);
+        } catch (error) {
+            console.error("[Phone] Failed to load config:", error);
+            return { enabled: false };
+        }
+
+        if (!config.enabled) {
+            return { enabled: false };
+        }
+
+        const bus = new EventBus();
+        const displayMode = config.displayMode || "dropdown";
+        let vertoClient = null;
+
+        // Ringtone state
+        let ringAudioCtx = null;
+        let ringOscillator = null;
+        let ringGain = null;
+        let ringing = false;
+        let ringTimeout = null;
+
+        function startRingtone() {
+            stopRingtone();
+            try {
+                ringAudioCtx = new AudioContext();
+                ringGain = ringAudioCtx.createGain();
+                ringGain.connect(ringAudioCtx.destination);
+                ringGain.gain.value = 0;
+
+                ringOscillator = ringAudioCtx.createOscillator();
+                ringOscillator.type = "sine";
+                ringOscillator.frequency.value = 440;
+                ringOscillator.connect(ringGain);
+                ringOscillator.start();
+
+                ringing = true;
+                const ringCycle = () => {
+                    if (!ringing) return;
+                    ringGain.gain.value = 0.3;
+                    ringTimeout = setTimeout(() => {
+                        if (!ringing) return;
+                        ringGain.gain.value = 0;
+                        ringTimeout = setTimeout(ringCycle, 2000);
+                    }, 1000);
+                };
+                ringCycle();
+            } catch (error) {
+                console.error("[Phone] Failed to start ringtone:", error);
+            }
+        }
+
+        function stopRingtone() {
+            ringing = false;
+            clearTimeout(ringTimeout);
+            if (ringOscillator) {
+                try { ringOscillator.stop(); } catch {}
+                ringOscillator = null;
+            }
+            if (ringAudioCtx) {
+                ringAudioCtx.close();
+                ringAudioCtx = null;
+            }
+            ringGain = null;
+        }
+
+        function connect() {
+            if (vertoClient) return;
+
+            vertoClient = new VertoClient({
+                socketUrl: config.socketUrl,
+                domain: config.domain,
+                login: config.login,
+                password: config.password,
+                callerName: config.callerName,
+                callerNumber: config.callerNumber,
+                onStateChange: (state) => {
+                    bus.trigger("phoneStateChanged", { vertoState: state });
+                },
+                onCallStateChange: (state, data) => {
+                    if (state === "incoming") {
+                        bus.trigger("phoneToggle", { show: true });
+                        startRingtone();
+                    } else {
+                        stopRingtone();
+                    }
+                    bus.trigger("phoneCallStateChanged", {
+                        callState: state,
+                        callerName: data.callerName || "",
+                        callerNumber: data.callerNumber || "",
+                    });
+                },
+                onError: (error) => {
+                    console.error("[Phone] Verto error:", error);
+                },
+            });
+
+            vertoClient.connect().catch((error) => {
+                console.error("[Phone] Connection failed:", error);
+            });
+        }
+
+        function disconnect() {
+            if (vertoClient) {
+                vertoClient.disconnect();
+                vertoClient = null;
+            }
+            stopRingtone();
+        }
+
+        const service = {
+            enabled: true,
+            bus,
+            config,
+            displayMode,
+            get vertoClient() { return vertoClient; },
+            connect,
+            disconnect,
+        };
+
+        registry.category("systray").add("connect_freeswitch.PhoneSystray", {
+            Component: PhoneSystray,
+            props: { bus, displayMode },
+        }, { sequence: 50 });
+
+        registry.category("main_components").add("connect_freeswitch.PhonePanel", {
+            Component: PhonePanel,
+            props: { bus, displayMode, getVertoClient: () => vertoClient, connect },
+        });
+
+        // Connect immediately
+        connect();
+
+        return service;
+    },
+};
+
+registry.category("services").add("connect_freeswitch.phone", phoneService);

--- a/connect_freeswitch/static/src/js/phone_systray.js
+++ b/connect_freeswitch/static/src/js/phone_systray.js
@@ -1,12 +1,9 @@
 /** @odoo-module **/
 
-import { Component, useState, useRef, onWillStart, onMounted, onWillUnmount } from "@odoo/owl";
-import { registry } from "@web/core/registry";
-import { useService } from "@web/core/utils/hooks";
-import { VertoClient } from "./verto_client";
+import { Component, useState, useRef, onMounted, onWillUnmount } from "@odoo/owl";
 
 
-class PhoneDialpad extends Component {
+export class PhoneDialpad extends Component {
     static template = "connect_freeswitch.PhoneDialpad";
     static props = {
         close: Function,
@@ -153,167 +150,41 @@ class PhoneDialpad extends Component {
 
 export class PhoneSystray extends Component {
     static template = "connect_freeswitch.PhoneSystray";
-    static components = { PhoneDialpad };
-    static props = {};
+    static props = {
+        bus: Object,
+        displayMode: String,
+    };
 
     setup() {
-        this.orm = useService("orm");
-
         this.state = useState({
-            enabled: false,
-            showDialpad: false,
             vertoState: "disconnected",
             callState: "idle",
-            callerName: "",
-            callerNumber: "",
-            config: null,
         });
 
-        this.vertoClient = null;
-        this._ringAudioCtx = null;
-        this._ringOscillator = null;
-        this._ringGain = null;
-        this._ringInterval = null;
-
-        onWillStart(async () => {
-            await this.loadConfig();
-        });
+        this._onStateChanged = ({ detail }) => {
+            this.state.vertoState = detail.vertoState;
+        };
+        this._onCallStateChanged = ({ detail }) => {
+            this.state.callState = detail.callState;
+        };
 
         onMounted(() => {
-            if (this.state.enabled) {
-                this.connect();
-            }
+            this.props.bus.addEventListener("phoneStateChanged", this._onStateChanged);
+            this.props.bus.addEventListener("phoneCallStateChanged", this._onCallStateChanged);
         });
 
         onWillUnmount(() => {
-            this.disconnect();
-            this._stopRingtone();
+            this.props.bus.removeEventListener("phoneStateChanged", this._onStateChanged);
+            this.props.bus.removeEventListener("phoneCallStateChanged", this._onCallStateChanged);
+            this.props.bus.trigger("phoneNavigated");
         });
-    }
-
-    async loadConfig() {
-        try {
-            const config = await this.orm.call("connect.settings", "get_webrtc_config", []);
-
-            if (config.enabled) {
-                this.state.enabled = true;
-                this.state.config = config;
-            }
-        } catch (error) {
-            console.error("[Phone] Failed to load config:", error);
-        }
-    }
-
-    async connect() {
-        if (!this.state.config || this.vertoClient) return;
-
-        this.vertoClient = new VertoClient({
-            socketUrl: this.state.config.socketUrl,
-            domain: this.state.config.domain,
-            login: this.state.config.login,
-            password: this.state.config.password,
-            callerName: this.state.config.callerName,
-            callerNumber: this.state.config.callerNumber,
-            onStateChange: (state) => {
-                this.state.vertoState = state;
-            },
-            onCallStateChange: (state, data) => {
-                this.state.callState = state;
-                if (state === "incoming") {
-                    this.state.showDialpad = true;
-                    this.state.callerName = data.callerName || "";
-                    this.state.callerNumber = data.callerNumber || "";
-                    this._startRingtone();
-                } else {
-                    this._stopRingtone();
-                    if (state === "idle") {
-                        this.state.callerName = "";
-                        this.state.callerNumber = "";
-                    } else if (data.callerName || data.callerNumber) {
-                        if (data.callerName) this.state.callerName = data.callerName;
-                        if (data.callerNumber) this.state.callerNumber = data.callerNumber;
-                    }
-                }
-            },
-            onError: (error) => {
-                console.error("[Phone] Verto error:", error);
-            }
-        });
-
-        try {
-            await this.vertoClient.connect();
-        } catch (error) {
-            console.error("[Phone] Connection failed:", error);
-        }
-    }
-
-    disconnect() {
-        if (this.vertoClient) {
-            this.vertoClient.disconnect();
-            this.vertoClient = null;
-        }
     }
 
     toggleDialpad() {
-        this.state.showDialpad = !this.state.showDialpad;
-
-        if (this.state.showDialpad && !this.vertoClient && this.state.enabled) {
-            this.connect();
-        }
-    }
-
-    closeDialpad() {
-        this.state.showDialpad = false;
-    }
-
-    _startRingtone() {
-        this._stopRingtone();
-        try {
-            this._ringAudioCtx = new AudioContext();
-            this._ringGain = this._ringAudioCtx.createGain();
-            this._ringGain.connect(this._ringAudioCtx.destination);
-            this._ringGain.gain.value = 0;
-
-            this._ringOscillator = this._ringAudioCtx.createOscillator();
-            this._ringOscillator.type = "sine";
-            this._ringOscillator.frequency.value = 440;
-            this._ringOscillator.connect(this._ringGain);
-            this._ringOscillator.start();
-
-            // Ring pattern: 1s on, 2s off
-            this._ringing = true;
-            const ringCycle = () => {
-                if (!this._ringing) return;
-                this._ringGain.gain.value = 0.3;
-                this._ringTimeout = setTimeout(() => {
-                    if (!this._ringing) return;
-                    this._ringGain.gain.value = 0;
-                    this._ringTimeout = setTimeout(ringCycle, 2000);
-                }, 1000);
-            };
-            ringCycle();
-        } catch (error) {
-            console.error("[Phone] Failed to start ringtone:", error);
-        }
-    }
-
-    _stopRingtone() {
-        this._ringing = false;
-        clearTimeout(this._ringTimeout);
-        if (this._ringOscillator) {
-            try { this._ringOscillator.stop(); } catch {}
-            this._ringOscillator = null;
-        }
-        if (this._ringAudioCtx) {
-            this._ringAudioCtx.close();
-            this._ringAudioCtx = null;
-        }
-        this._ringGain = null;
+        this.props.bus.trigger("phoneToggle");
     }
 
     getIconClass() {
-        if (!this.state.enabled) return "text-muted";
-
         switch (this.state.vertoState) {
             case "registered":
                 return this.state.callState !== "idle" ? "text-success" : "";
@@ -327,7 +198,3 @@ export class PhoneSystray extends Component {
         }
     }
 }
-
-registry.category("systray").add("connect_freeswitch.PhoneSystray", {
-    Component: PhoneSystray,
-}, { sequence: 50 });

--- a/connect_freeswitch/static/src/js/phone_systray.js
+++ b/connect_freeswitch/static/src/js/phone_systray.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { Component, useState, useRef, onMounted, onWillUnmount } from "@odoo/owl";
+import { Component, useState, useRef, onMounted, onWillUnmount, useExternalListener } from "@odoo/owl";
 
 
 export class PhoneDialpad extends Component {
@@ -156,6 +156,8 @@ export class PhoneSystray extends Component {
     };
 
     setup() {
+        this.iconRef = useRef("iconRef");
+
         this.state = useState({
             vertoState: "disconnected",
             callState: "idle",
@@ -181,7 +183,8 @@ export class PhoneSystray extends Component {
     }
 
     toggleDialpad() {
-        this.props.bus.trigger("phoneToggle");
+        const rect = this.iconRef.el?.getBoundingClientRect();
+        this.props.bus.trigger("phoneToggle", { anchorRect: rect || null });
     }
 
     getIconClass() {

--- a/connect_freeswitch/static/src/js/phone_systray.js
+++ b/connect_freeswitch/static/src/js/phone_systray.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { Component, useState, useRef, onMounted, onWillUnmount, useExternalListener } from "@odoo/owl";
+import { Component, useState, useRef, onMounted, onWillUnmount } from "@odoo/owl";
 
 
 export class PhoneDialpad extends Component {
@@ -156,8 +156,6 @@ export class PhoneSystray extends Component {
     };
 
     setup() {
-        this.iconRef = useRef("iconRef");
-
         this.state = useState({
             vertoState: "disconnected",
             callState: "idle",
@@ -183,8 +181,7 @@ export class PhoneSystray extends Component {
     }
 
     toggleDialpad() {
-        const rect = this.iconRef.el?.getBoundingClientRect();
-        this.props.bus.trigger("phoneToggle", { anchorRect: rect || null });
+        this.props.bus.trigger("phoneToggle");
     }
 
     getIconClass() {

--- a/connect_freeswitch/static/src/js/phone_systray.js
+++ b/connect_freeswitch/static/src/js/phone_systray.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { Component, useState, onWillStart, onMounted, onWillUnmount } from "@odoo/owl";
+import { Component, useState, useRef, onWillStart, onMounted, onWillUnmount } from "@odoo/owl";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { VertoClient } from "./verto_client";
@@ -24,11 +24,22 @@ class PhoneDialpad extends Component {
             callDuration: 0,
         });
 
+        this.numberInput = useRef("numberInput");
         this.durationInterval = null;
+
+        onMounted(() => {
+            this.numberInput.el?.focus();
+        });
 
         onWillUnmount(() => {
             this._stopDurationTimer();
         });
+    }
+
+    onInputKeydown(ev) {
+        if (ev.key === "Enter") {
+            this.onCall();
+        }
     }
 
     get isConnected() {

--- a/connect_freeswitch/static/src/xml/phone_systray.xml
+++ b/connect_freeswitch/static/src/xml/phone_systray.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="connect_freeswitch.PhoneSystray">
-        <li class="o_nav_entry o_phone_systray" t-ref="iconRef">
+        <li class="o_nav_entry o_phone_systray">
             <a href="#" class="dropdown-toggle" t-on-click.prevent="toggleDialpad" t-att-class="getIconClass()">
                 <i class="fa fa-phone"/>
             </a>
@@ -10,7 +10,7 @@
     </t>
 
     <t t-name="connect_freeswitch.PhonePanel">
-        <div t-att-class="modeClass" t-ref="panelRef" t-if="state.showDialpad">
+        <div t-att-class="modeClass" t-if="state.showDialpad">
             <PhoneDialpad
                 close.bind="closeDialpad"
                 vertoClient="props.getVertoClient()"

--- a/connect_freeswitch/static/src/xml/phone_systray.xml
+++ b/connect_freeswitch/static/src/xml/phone_systray.xml
@@ -2,20 +2,24 @@
 <templates xml:space="preserve">
 
     <t t-name="connect_freeswitch.PhoneSystray">
-        <li class="o_nav_entry o_phone_systray" t-if="state.enabled">
+        <li class="o_nav_entry o_phone_systray">
             <a href="#" class="dropdown-toggle" t-on-click.prevent="toggleDialpad" t-att-class="getIconClass()">
                 <i class="fa fa-phone"/>
             </a>
+        </li>
+    </t>
+
+    <t t-name="connect_freeswitch.PhonePanel">
+        <div t-att-class="modeClass" t-if="state.showDialpad">
             <PhoneDialpad
-                t-if="state.showDialpad"
                 close.bind="closeDialpad"
-                vertoClient="vertoClient"
+                vertoClient="props.getVertoClient()"
                 state="state.vertoState"
                 callState="state.callState"
                 callerName="state.callerName"
                 callerNumber="state.callerNumber"
             />
-        </li>
+        </div>
     </t>
 
     <t t-name="connect_freeswitch.PhoneDialpad">
@@ -28,7 +32,7 @@
                 </span>
                 <button class="btn btn-sm btn-close" t-on-click="props.close"/>
             </div>
-            
+
             <div class="o_phone_dialpad_display">
                 <div class="o_phone_number" t-if="!isIncoming and !isCallActive">
                     <input type="text"
@@ -95,7 +99,7 @@
 
             <div class="o_phone_dialpad_actions">
                 <t t-if="props.callState === 'idle'">
-                    <button class="btn btn-success o_phone_call_btn" 
+                    <button class="btn btn-success o_phone_call_btn"
                             t-on-click="onCall"
                             t-att-disabled="!state.number or !isConnected">
                         <i class="fa fa-phone"/> Call
@@ -110,7 +114,7 @@
                     </button>
                 </t>
                 <t t-else="">
-                    <button class="btn o_phone_mute_btn" 
+                    <button class="btn o_phone_mute_btn"
                             t-att-class="state.muted ? 'btn-warning' : 'btn-outline-secondary'"
                             t-on-click="onToggleMute">
                         <i t-att-class="state.muted ? 'fa fa-microphone-slash' : 'fa fa-microphone'"/>

--- a/connect_freeswitch/static/src/xml/phone_systray.xml
+++ b/connect_freeswitch/static/src/xml/phone_systray.xml
@@ -33,7 +33,9 @@
                 <div class="o_phone_number" t-if="!isIncoming and !isCallActive">
                     <input type="text"
                            class="form-control form-control-lg text-center"
+                           t-ref="numberInput"
                            t-model="state.number"
+                           t-on-keydown="onInputKeydown"
                            placeholder="Enter number"/>
                 </div>
                 <div class="o_phone_incoming_info" t-if="isIncoming or isCallActive">

--- a/connect_freeswitch/static/src/xml/phone_systray.xml
+++ b/connect_freeswitch/static/src/xml/phone_systray.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="connect_freeswitch.PhoneSystray">
-        <li class="o_nav_entry o_phone_systray">
+        <li class="o_nav_entry o_phone_systray" t-ref="iconRef">
             <a href="#" class="dropdown-toggle" t-on-click.prevent="toggleDialpad" t-att-class="getIconClass()">
                 <i class="fa fa-phone"/>
             </a>
@@ -10,7 +10,7 @@
     </t>
 
     <t t-name="connect_freeswitch.PhonePanel">
-        <div t-att-class="modeClass" t-if="state.showDialpad">
+        <div t-att-class="modeClass" t-ref="panelRef" t-if="state.showDialpad">
             <PhoneDialpad
                 close.bind="closeDialpad"
                 vertoClient="props.getVertoClient()"

--- a/connect_freeswitch/views/user_views.xml
+++ b/connect_freeswitch/views/user_views.xml
@@ -19,6 +19,8 @@
                             <field name="webrtc_enabled" widget="boolean_toggle"/>
                             <field name="originate_ring" widget="boolean_toggle"
                                    invisible="not webrtc_enabled"/>
+                            <field name="phone_display_mode" widget="radio"
+                                   invisible="not webrtc_enabled"/>
                         </group>
                     </group>
                 </page>


### PR DESCRIPTION
## Summary
- Adds per-user `phone_display_mode` setting (Dropdown / Floating Panel) on the WebRTC config page
- **Dropdown** (default): phone panel appears below the systray icon and auto-hides on navigation
- **Floating Panel**: phone panel is fixed at bottom-left, persists across navigations until explicitly closed
- Refactors phone widget architecture: extracts VertoClient lifecycle into a phone service, registers the dialpad as a `main_component` for navigation persistence, and keeps the systray as a thin icon-only component
- Also includes UX fixes: autofocus on number input and Enter-to-call

## Test plan
- [x] Set user to "Dropdown" mode → phone appears below icon, hides on navigation
- [x] Set user to "Floating Panel" mode → phone appears bottom-left, persists across navigation
- [x] Incoming calls auto-show the phone in both modes
- [x] WebSocket connection survives page navigations
- [ ] Enter key initiates call from number input

🤖 Generated with [Claude Code](https://claude.com/claude-code)