### PR TITLE
Fix slow Verto WebRTC answer + configurable ICE servers

### DIFF
--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.4.0',
+    'version': '19.0.1.5.0',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',
     'depends': ['connect', 'web'],

--- a/connect_freeswitch/migrations/19.0.1.5.0/post-migrate.py
+++ b/connect_freeswitch/migrations/19.0.1.5.0/post-migrate.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+import logging
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ICE_SERVERS = (
+    "stun:stun.l.google.com:19302\n"
+    "stun:stun1.l.google.com:19302\n"
+    "stun:stun.cloudflare.com:3478\n"
+    "stun:stun.nextcloud.com:443"
+)
+
+
+def migrate(cr, version):
+    """Populate default ICE servers for existing installations."""
+    cr.execute(
+        "UPDATE connect_settings SET freeswitch_ice_servers = %s "
+        "WHERE freeswitch_ice_servers IS NULL",
+        (DEFAULT_ICE_SERVERS,),
+    )
+    updated = cr.rowcount
+    logger.info("Set default ICE servers on %d settings record(s)", updated)

--- a/connect_freeswitch/models/settings.py
+++ b/connect_freeswitch/models/settings.py
@@ -24,6 +24,16 @@ class Settings(models.Model):
         help="SIP domain for FreeSWITCH registrations and routing. "
              "Used in sofia profile (force-register-domain) and directory XML.",
     )
+    freeswitch_ice_servers = fields.Text(
+        string="ICE Servers",
+        default="stun:stun.l.google.com:19302\n"
+                "stun:stun1.l.google.com:19302\n"
+                "stun:stun.cloudflare.com:3478\n"
+                "stun:stun.nextcloud.com:443",
+        help="STUN/TURN server URIs for WebRTC, one per line. "
+             "Example: stun:stun.example.com:3478 or "
+             "turn:turn.example.com:3478?transport=udp",
+    )
     freeswitch_log_level = fields.Selection(
         selection=[
             ('alert', 'ALERT'),
@@ -219,6 +229,13 @@ class Settings(models.Model):
         if not socket_url:
             return {'enabled': False, 'reason': 'no_socket_url'}
 
+        ice_servers_text = self.get_param('freeswitch_ice_servers') or ''
+        ice_servers = []
+        for line in ice_servers_text.splitlines():
+            url = line.strip()
+            if url:
+                ice_servers.append({'urls': url})
+
         return {
             'enabled': True,
             'socketUrl': socket_url,
@@ -228,4 +245,5 @@ class Settings(models.Model):
             'callerName': connect_user.name,
             'callerNumber': connect_user.exten_number or user.login,
             'displayMode': connect_user.phone_display_mode or 'dropdown',
+            'iceServers': ice_servers,
         }

--- a/connect_freeswitch/static/src/js/phone_service.js
+++ b/connect_freeswitch/static/src/js/phone_service.js
@@ -93,6 +93,7 @@ export const phoneService = {
                 password: config.password,
                 callerName: config.callerName,
                 callerNumber: config.callerNumber,
+                iceServers: config.iceServers,
                 onStateChange: (state) => {
                     bus.trigger("phoneStateChanged", { vertoState: state });
                 },

--- a/connect_freeswitch/static/src/js/verto_client.js
+++ b/connect_freeswitch/static/src/js/verto_client.js
@@ -44,11 +44,11 @@ export class VertoClient {
         this.lastPong = Date.now();
         
         // ICE settings
-        this.iceGatheringTimeout = 10000;
-        
-        this.iceServers = options.iceServers || [
-            { urls: 'stun:stun.l.google.com:19302' }
-        ];
+        this.iceGatheringTimeout = 2000;
+
+        this.iceServers = options.iceServers?.length
+            ? options.iceServers
+            : [{ urls: 'stun:stun.l.google.com:19302' }];
     }
     
     _loadOrCreateSessionId() {
@@ -600,21 +600,34 @@ export class VertoClient {
                 resolve();
                 return;
             }
-            
-            const checkComplete = () => {
-                if (this.peerConnection?.iceGatheringState === 'complete') {
-                    this.peerConnection.onicegatheringstatechange = null;
-                    resolve();
-                }
-            };
-            
-            this.peerConnection.onicegatheringstatechange = checkComplete;
-            setTimeout(() => {
+
+            let resolved = false;
+            const done = () => {
+                if (resolved) return;
+                resolved = true;
                 if (this.peerConnection) {
                     this.peerConnection.onicegatheringstatechange = null;
+                    this.peerConnection.onicecandidate = null;
                 }
                 resolve();
-            }, this.iceGatheringTimeout);
+            };
+
+            // Resolve when gathering completes naturally
+            this.peerConnection.onicegatheringstatechange = () => {
+                if (this.peerConnection?.iceGatheringState === 'complete') {
+                    done();
+                }
+            };
+
+            // Resolve on first ICE candidate (host candidates arrive instantly)
+            this.peerConnection.onicecandidate = (event) => {
+                if (event.candidate) {
+                    done();
+                }
+            };
+
+            // Fallback timeout
+            setTimeout(done, this.iceGatheringTimeout);
         });
     }
 

--- a/connect_freeswitch/views/settings.xml
+++ b/connect_freeswitch/views/settings.xml
@@ -29,6 +29,8 @@
                                    placeholder="wss://your-fs-domain:8082"/>
                             <field name="freeswitch_domain"
                                    placeholder="fs.example.com"/>
+                            <field name="freeswitch_ice_servers"
+                                   placeholder="stun:stun.l.google.com:19302"/>
                         </group>
                         <group string="XML-RPC">
                             <field name="freeswitch_xmlrpc_host"

--- a/docs/admin/freeswitch-setup.md
+++ b/docs/admin/freeswitch-setup.md
@@ -87,6 +87,7 @@ Navigate to **Connect > Configuration > Settings** and open the **FreeSWITCH** t
 |-------|-------------|
 | **WebSocket URL** | Verto WSS URL for the browser phone (e.g., `wss://fs.example.com:48082`). |
 | **Domain** | SIP domain for FreeSWITCH registrations and routing. |
+| **ICE Servers** | STUN/TURN server URIs for WebRTC (one per line). Pre-populated with public STUN servers. Customize if you use private TURN servers or need to change STUN endpoints. |
 
 #### XML-RPC
 


### PR DESCRIPTION
## Summary

- Fix ~5s delay when answering incoming Verto WebRTC calls by resolving ICE gathering on the first host candidate instead of waiting for full STUN completion
- Add configurable **ICE Servers** text field to FreeSWITCH settings (one URI per line), pre-populated with public STUN servers, so admins can customize STUN/TURN endpoints
- Reduce ICE gathering fallback timeout from 10s to 2s
- Pass ICE servers from backend config to the JS Verto client instead of hardcoding Google STUN
- Include migration (`19.0.1.5.0`) to populate default ICE servers for existing installations

## Test plan

- [x] Deploy to oduflow environment, upgrade `connect_freeswitch`
- [x] Verify ICE Servers field appears in Settings → FreeSWITCH → Connection with default values
- [x] Test incoming call — answer delay should drop from ~5s to <1s
- [x] Test outgoing call — same improvement expected
- [x] Modify ICE servers in settings, verify new values are used by the browser client

🤖 Generated with [Claude Code](https://claude.com/claude-code)