### PR TITLE
feat(freeswitch): call parking with BLF, Verto tab, and Park button

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"c1e2a747-a588-46c5-b5e1-0bdd7f873ab4","pid":14019,"acquiredAt":1776784731064}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"c1e2a747-a588-46c5-b5e1-0bdd7f873ab4","pid":14019,"acquiredAt":1776784731064}

--- a/connect/__manifest__.py
+++ b/connect/__manifest__.py
@@ -1,6 +1,7 @@
 {
     'name': 'Oduist Connect',
     'version': '19.0.1.1.0',
+    'author': 'Oduist',
     'category': 'Phone',
     'summary': 'Communication platform for Odoo',
     'depends': ['base', 'mail', 'contacts', 'sms'],

--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.7.8',
+    'version': '19.0.1.7.9',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',

--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.7.3',
+    'version': '19.0.1.7.4',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',

--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.6.0',
+    'version': '19.0.1.7.0',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',
@@ -8,11 +8,14 @@
     'data': [
         'security/access_rules.xml',
         'data/fs_templates.xml',
+        'data/parking_slots.xml',
         'views/endpoint_views.xml',
         'views/fs_template_views.xml',
         'views/user_views.xml',
         'views/gateway_views.xml',
         'views/outgoing_route_views.xml',
+        'views/fs_parking_slot_views.xml',
+        'views/call_views.xml',
         'views/settings.xml',
     ],
     'assets': {
@@ -22,7 +25,9 @@
             'connect_freeswitch/static/src/js/phone_systray.js',
             'connect_freeswitch/static/src/js/phone_panel.js',
             'connect_freeswitch/static/src/js/phone_service.js',
+            'connect_freeswitch/static/src/js/parking_panel.js',
             'connect_freeswitch/static/src/xml/phone_systray.xml',
+            'connect_freeswitch/static/src/xml/parking_panel.xml',
             'connect_freeswitch/static/src/widgets/phone_field/*',
         ],
     },

--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.7.6',
+    'version': '19.0.1.7.7',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',

--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,7 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.5.0',
+    'version': '19.0.1.6.0',
+    'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',
     'depends': ['connect', 'web'],

--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.7.4',
+    'version': '19.0.1.7.6',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',

--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.7.2',
+    'version': '19.0.1.7.3',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',

--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.7.9',
+    'version': '19.0.1.7.10',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',

--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.7.1',
+    'version': '19.0.1.7.2',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',

--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.7.7',
+    'version': '19.0.1.7.8',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',

--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.7.0',
+    'version': '19.0.1.7.1',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',

--- a/connect_freeswitch/controllers/__init__.py
+++ b/connect_freeswitch/controllers/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from . import freeswitch_cdr
+from . import freeswitch_parking
 from . import freeswitch_recording
 from . import freeswitch_xml
 from . import webrtc

--- a/connect_freeswitch/controllers/freeswitch_parking.py
+++ b/connect_freeswitch/controllers/freeswitch_parking.py
@@ -1,0 +1,57 @@
+import logging
+
+from odoo import http
+from odoo.http import request, Response
+
+logger = logging.getLogger(__name__)
+
+
+class FreeSwitchParkingController(http.Controller):
+    """Webhook endpoints for FreeSWITCH valet parking events.
+
+    The valet parking dialplan extension (served by freeswitch_xml.py)
+    calls this endpoint twice per park cycle:
+
+      - `event=entered` when the channel first enters the lot (via
+        `curl ... background`), with UUID and caller info so we can show
+        the parked party in the UI before the CDR arrives.
+      - `event=released` as the channel's api_hangup_hook, when the
+        channel leaves the lot (retrieved, transferred, or hung up).
+
+    Both events are idempotent — replays are safe.
+    """
+
+    @http.route(
+        '/freeswitch/webhook/parking',
+        type='http', auth='none', methods=['GET', 'POST'], csrf=False,
+    )
+    def parking_webhook(self, **kwargs):
+        event = kwargs.get('event')
+        exten = kwargs.get('slot')
+        if not event or not exten:
+            return Response('Missing event or slot', status=400)
+
+        Slot = request.env['connect.freeswitch.parking.slot'].sudo()
+
+        try:
+            if event == 'entered':
+                uuid = kwargs.get('uuid') or ''
+                if not uuid:
+                    return Response('Missing uuid', status=400)
+                Slot.on_parking_entered(
+                    exten=exten,
+                    uuid=uuid,
+                    caller_number=kwargs.get('caller_number', ''),
+                    caller_name=kwargs.get('caller_name', ''),
+                )
+            elif event == 'released':
+                Slot.on_parking_released(exten=exten)
+            else:
+                return Response('Unknown event', status=400)
+        except Exception as e:
+            logger.exception(
+                'Parking webhook failed (event=%s, slot=%s): %s',
+                event, exten, e)
+            return Response('Processing error', status=500)
+
+        return Response('OK', status=200)

--- a/connect_freeswitch/controllers/freeswitch_xml.py
+++ b/connect_freeswitch/controllers/freeswitch_xml.py
@@ -354,6 +354,20 @@ class FreeSwitchXMLController(http.Controller):
         Template = request.env['connect.freeswitch.template'].sudo()
         parts.append(Template.render('dialplan_system', {}))
 
+        # Valet parking slots (park/unpark by dialing slot extension)
+        ParkingSlot = request.env['connect.freeswitch.parking.slot'].sudo()
+        parking_slot = ParkingSlot.search(
+            [('exten', '=', destination), ('active', '=', True)], limit=1)
+        if parking_slot:
+            webhook_url = request.env['ir.config_parameter'].sudo().get_param(
+                'web.base.url') or ''
+            parts.append(Template.render('dialplan_valet_parking', {
+                'slot': parking_slot.exten,
+                'lot_name': 'default',
+                'webhook_url': webhook_url,
+            }))
+            return ''.join(parts)
+
         # Try exact extension match
         exten = Exten.search([('number', '=', destination)], limit=1)
         if exten:

--- a/connect_freeswitch/data/fs_templates.xml
+++ b/connect_freeswitch/data/fs_templates.xml
@@ -409,6 +409,10 @@ Variables:
         <param name="codec-prefs" value="OPUS,PCMU,PCMA"/>
         <param name="auth-calls" value="true"/>
         <param name="apply-inbound-acl" value="gateways"/>
+        <param name="NDLB-received-in-nat-reg-contact" value="true"/>
+        <param name="aggressive-nat-detection" value="true"/>
+        <param name="NDLB-force-rport" value="true"/>
+        <param name="force-rport" value="true"/>
         {% if fs_domain %}
         <param name="force-register-domain" value="{{ fs_domain }}"/>
         <param name="force-realm" value="{{ fs_domain }}"/>
@@ -434,6 +438,10 @@ Variables:
         <param name="codec-prefs" value="OPUS,PCMU,PCMA"/>
         <param name="auth-calls" value="true"/>
         <param name="apply-inbound-acl" value="gateways"/>
+        <param name="NDLB-received-in-nat-reg-contact" value="true"/>
+        <param name="aggressive-nat-detection" value="true"/>
+        <param name="NDLB-force-rport" value="true"/>
+        <param name="force-rport" value="true"/>
         {% if fs_domain %}
         <param name="force-register-domain" value="{{ fs_domain }}"/>
         <param name="force-realm" value="{{ fs_domain }}"/>

--- a/connect_freeswitch/data/fs_templates.xml
+++ b/connect_freeswitch/data/fs_templates.xml
@@ -380,6 +380,8 @@ Variables:
     <action application="answer"/>
     <action application="set" data="valet_hold_music=silence_stream://-1"/>
     <action application="set" data="presence_id={{ slot }}@${domain_name}"/>
+    <action application="set" data="execute_on_valet_hold=presence in ${presence_id} active Parked"/>
+    <action application="set" data="execute_on_hangup=presence out ${presence_id} away Idle"/>
     <action application="set" data="api_hangup_hook=bgapi curl {{ webhook_url }}/freeswitch/webhook/parking?event=released&amp;slot={{ slot }}"/>
     <action application="curl" data="{{ webhook_url }}/freeswitch/webhook/parking?event=entered&amp;slot={{ slot }}&amp;uuid=${uuid}&amp;caller_number=${caller_id_number}&amp;caller_name=${caller_id_name} background"/>
     <action application="valet_park" data="{{ lot_name }} {{ slot }}"/>
@@ -390,6 +392,8 @@ Variables:
     <action application="answer"/>
     <action application="set" data="valet_hold_music=silence_stream://-1"/>
     <action application="set" data="presence_id={{ slot }}@${domain_name}"/>
+    <action application="set" data="execute_on_valet_hold=presence in ${presence_id} active Parked"/>
+    <action application="set" data="execute_on_hangup=presence out ${presence_id} away Idle"/>
     <action application="set" data="api_hangup_hook=bgapi curl {{ webhook_url }}/freeswitch/webhook/parking?event=released&amp;slot={{ slot }}"/>
     <action application="curl" data="{{ webhook_url }}/freeswitch/webhook/parking?event=entered&amp;slot={{ slot }}&amp;uuid=${uuid}&amp;caller_number=${caller_id_number}&amp;caller_name=${caller_id_name} background"/>
     <action application="valet_park" data="{{ lot_name }} {{ slot }}"/>

--- a/connect_freeswitch/data/fs_templates.xml
+++ b/connect_freeswitch/data/fs_templates.xml
@@ -378,6 +378,7 @@ Variables:
         <field name="content"><![CDATA[<extension name="connect_valet_parking_{{ slot }}">
   <condition field="destination_number" expression="^{{ slot }}$">
     <action application="answer"/>
+    <action application="set" data="valet_hold_music=silence_stream://-1"/>
     <action application="set" data="presence_id={{ slot }}@${domain_name}"/>
     <action application="set" data="api_hangup_hook=bgapi curl {{ webhook_url }}/freeswitch/webhook/parking?event=released&amp;slot={{ slot }}"/>
     <action application="curl" data="{{ webhook_url }}/freeswitch/webhook/parking?event=entered&amp;slot={{ slot }}&amp;uuid=${uuid}&amp;caller_number=${caller_id_number}&amp;caller_name=${caller_id_name} background"/>
@@ -387,6 +388,7 @@ Variables:
         <field name="default_content"><![CDATA[<extension name="connect_valet_parking_{{ slot }}">
   <condition field="destination_number" expression="^{{ slot }}$">
     <action application="answer"/>
+    <action application="set" data="valet_hold_music=silence_stream://-1"/>
     <action application="set" data="presence_id={{ slot }}@${domain_name}"/>
     <action application="set" data="api_hangup_hook=bgapi curl {{ webhook_url }}/freeswitch/webhook/parking?event=released&amp;slot={{ slot }}"/>
     <action application="curl" data="{{ webhook_url }}/freeswitch/webhook/parking?event=entered&amp;slot={{ slot }}&amp;uuid=${uuid}&amp;caller_number=${caller_id_number}&amp;caller_name=${caller_id_name} background"/>

--- a/connect_freeswitch/data/fs_templates.xml
+++ b/connect_freeswitch/data/fs_templates.xml
@@ -380,10 +380,10 @@ Variables:
     <action application="answer"/>
     <action application="set" data="valet_hold_music=silence_stream://-1"/>
     <action application="set" data="presence_id={{ slot }}@${domain_name}"/>
-    <action application="set" data="execute_on_valet_hold=presence in ${presence_id} active Parked"/>
-    <action application="set" data="execute_on_hangup=presence out ${presence_id} away Idle"/>
+    <action application="set" data="execute_on_hangup=event Event-Name=PRESENCE_IN,proto=sip,login=${presence_id},from=${presence_id},event_type=presence,alt_event_type=dialog,status=Idle,rpid=away,answer-state=terminated"/>
     <action application="set" data="api_hangup_hook=bgapi curl {{ webhook_url }}/freeswitch/webhook/parking?event=released&amp;slot={{ slot }}"/>
     <action application="curl" data="{{ webhook_url }}/freeswitch/webhook/parking?event=entered&amp;slot={{ slot }}&amp;uuid=${uuid}&amp;caller_number=${caller_id_number}&amp;caller_name=${caller_id_name} background"/>
+    <action application="event" data="Event-Name=PRESENCE_IN,proto=sip,login=${presence_id},from=${presence_id},event_type=presence,alt_event_type=dialog,status=Parked,rpid=active,answer-state=confirmed"/>
     <action application="valet_park" data="{{ lot_name }} {{ slot }}"/>
   </condition>
 </extension>]]></field>
@@ -392,10 +392,10 @@ Variables:
     <action application="answer"/>
     <action application="set" data="valet_hold_music=silence_stream://-1"/>
     <action application="set" data="presence_id={{ slot }}@${domain_name}"/>
-    <action application="set" data="execute_on_valet_hold=presence in ${presence_id} active Parked"/>
-    <action application="set" data="execute_on_hangup=presence out ${presence_id} away Idle"/>
+    <action application="set" data="execute_on_hangup=event Event-Name=PRESENCE_IN,proto=sip,login=${presence_id},from=${presence_id},event_type=presence,alt_event_type=dialog,status=Idle,rpid=away,answer-state=terminated"/>
     <action application="set" data="api_hangup_hook=bgapi curl {{ webhook_url }}/freeswitch/webhook/parking?event=released&amp;slot={{ slot }}"/>
     <action application="curl" data="{{ webhook_url }}/freeswitch/webhook/parking?event=entered&amp;slot={{ slot }}&amp;uuid=${uuid}&amp;caller_number=${caller_id_number}&amp;caller_name=${caller_id_name} background"/>
+    <action application="event" data="Event-Name=PRESENCE_IN,proto=sip,login=${presence_id},from=${presence_id},event_type=presence,alt_event_type=dialog,status=Parked,rpid=active,answer-state=confirmed"/>
     <action application="valet_park" data="{{ lot_name }} {{ slot }}"/>
   </condition>
 </extension>]]></field>

--- a/connect_freeswitch/data/fs_templates.xml
+++ b/connect_freeswitch/data/fs_templates.xml
@@ -365,6 +365,36 @@ Variables:
 </extension>]]></field>
     </record>
 
+    <record id="fs_template_dialplan_valet_parking" model="connect.freeswitch.template">
+        <field name="key">dialplan_valet_parking</field>
+        <field name="name">Dialplan - Valet Parking</field>
+        <field name="section">dialplan</field>
+        <field name="description">Valet parking extension. Dialing a slot extension either parks the current call (if slot is free) or retrieves the parked call (if occupied). The webhook notifies Odoo when a channel enters/leaves the lot.
+
+Variables:
+  slot        - Slot extension number (e.g. "701")
+  lot_name    - Valet parking lot name (usually "default")
+  webhook_url - Odoo base URL (https://...) for parking event callbacks</field>
+        <field name="content"><![CDATA[<extension name="connect_valet_parking_{{ slot }}">
+  <condition field="destination_number" expression="^{{ slot }}$">
+    <action application="answer"/>
+    <action application="set" data="presence_id={{ slot }}@${domain_name}"/>
+    <action application="set" data="api_hangup_hook=bgapi curl {{ webhook_url }}/freeswitch/webhook/parking?event=released&amp;slot={{ slot }}"/>
+    <action application="curl" data="{{ webhook_url }}/freeswitch/webhook/parking?event=entered&amp;slot={{ slot }}&amp;uuid=${uuid}&amp;caller_number=${caller_id_number}&amp;caller_name=${caller_id_name} background"/>
+    <action application="valet_park" data="{{ lot_name }} {{ slot }}"/>
+  </condition>
+</extension>]]></field>
+        <field name="default_content"><![CDATA[<extension name="connect_valet_parking_{{ slot }}">
+  <condition field="destination_number" expression="^{{ slot }}$">
+    <action application="answer"/>
+    <action application="set" data="presence_id={{ slot }}@${domain_name}"/>
+    <action application="set" data="api_hangup_hook=bgapi curl {{ webhook_url }}/freeswitch/webhook/parking?event=released&amp;slot={{ slot }}"/>
+    <action application="curl" data="{{ webhook_url }}/freeswitch/webhook/parking?event=entered&amp;slot={{ slot }}&amp;uuid=${uuid}&amp;caller_number=${caller_id_number}&amp;caller_name=${caller_id_name} background"/>
+    <action application="valet_park" data="{{ lot_name }} {{ slot }}"/>
+  </condition>
+</extension>]]></field>
+    </record>
+
     <record id="fs_template_dialplan_system" model="connect.freeswitch.template">
         <field name="key">dialplan_system</field>
         <field name="name">Dialplan - System Extensions</field>
@@ -413,10 +443,13 @@ Variables:
         <param name="aggressive-nat-detection" value="true"/>
         <param name="NDLB-force-rport" value="true"/>
         <param name="force-rport" value="true"/>
+        <param name="manage-presence" value="true"/>
+        <param name="send-presence-on-register" value="first-register"/>
         {% if fs_domain %}
         <param name="force-register-domain" value="{{ fs_domain }}"/>
         <param name="force-realm" value="{{ fs_domain }}"/>
         <param name="force-register-db-domain" value="{{ fs_domain }}"/>
+        <param name="presence-hosts" value="{{ fs_domain }},${local_ip_v4}"/>
         {% endif %}
       </settings>
       <gateways>
@@ -442,10 +475,13 @@ Variables:
         <param name="aggressive-nat-detection" value="true"/>
         <param name="NDLB-force-rport" value="true"/>
         <param name="force-rport" value="true"/>
+        <param name="manage-presence" value="true"/>
+        <param name="send-presence-on-register" value="first-register"/>
         {% if fs_domain %}
         <param name="force-register-domain" value="{{ fs_domain }}"/>
         <param name="force-realm" value="{{ fs_domain }}"/>
         <param name="force-register-db-domain" value="{{ fs_domain }}"/>
+        <param name="presence-hosts" value="{{ fs_domain }},${local_ip_v4}"/>
         {% endif %}
       </settings>
       <gateways>

--- a/connect_freeswitch/data/parking_slots.xml
+++ b/connect_freeswitch/data/parking_slots.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <record id="parking_slot_701" model="connect.freeswitch.parking.slot">
+        <field name="name">Slot 701</field>
+        <field name="exten">701</field>
+        <field name="sequence">10</field>
+    </record>
+
+    <record id="parking_slot_702" model="connect.freeswitch.parking.slot">
+        <field name="name">Slot 702</field>
+        <field name="exten">702</field>
+        <field name="sequence">20</field>
+    </record>
+
+    <record id="parking_slot_703" model="connect.freeswitch.parking.slot">
+        <field name="name">Slot 703</field>
+        <field name="exten">703</field>
+        <field name="sequence">30</field>
+    </record>
+
+    <record id="parking_slot_704" model="connect.freeswitch.parking.slot">
+        <field name="name">Slot 704</field>
+        <field name="exten">704</field>
+        <field name="sequence">40</field>
+    </record>
+
+    <record id="parking_slot_705" model="connect.freeswitch.parking.slot">
+        <field name="name">Slot 705</field>
+        <field name="exten">705</field>
+        <field name="sequence">50</field>
+    </record>
+
+    <record id="parking_slot_706" model="connect.freeswitch.parking.slot">
+        <field name="name">Slot 706</field>
+        <field name="exten">706</field>
+        <field name="sequence">60</field>
+    </record>
+
+</odoo>

--- a/connect_freeswitch/deploy/Dockerfile
+++ b/connect_freeswitch/deploy/Dockerfile
@@ -68,6 +68,7 @@ endpoints/mod_loopback
 endpoints/mod_rtc
 endpoints/mod_verto
 applications/mod_commands
+applications/mod_curl
 applications/mod_dptools
 applications/mod_http_cache
 applications/mod_valet_parking

--- a/connect_freeswitch/deploy/Dockerfile
+++ b/connect_freeswitch/deploy/Dockerfile
@@ -70,6 +70,7 @@ endpoints/mod_verto
 applications/mod_commands
 applications/mod_dptools
 applications/mod_http_cache
+applications/mod_valet_parking
 dialplans/mod_dialplan_xml
 codecs/mod_opus
 formats/mod_sndfile

--- a/connect_freeswitch/deploy/freeswitch/conf/autoload_configs/modules.conf.xml
+++ b/connect_freeswitch/deploy/freeswitch/conf/autoload_configs/modules.conf.xml
@@ -22,6 +22,7 @@
     <load module="mod_dptools"/>
     <load module="mod_http_cache"/>
     <load module="mod_dialplan_xml"/>
+    <load module="mod_valet_parking"/>
 
     <!-- Codecs -->
     <load module="mod_opus"/>

--- a/connect_freeswitch/deploy/freeswitch/conf/autoload_configs/modules.conf.xml
+++ b/connect_freeswitch/deploy/freeswitch/conf/autoload_configs/modules.conf.xml
@@ -19,6 +19,7 @@
 
     <!-- Applications -->
     <load module="mod_commands"/>
+    <load module="mod_curl"/>
     <load module="mod_dptools"/>
     <load module="mod_http_cache"/>
     <load module="mod_dialplan_xml"/>

--- a/connect_freeswitch/deploy/freeswitch/conf/vars.xml
+++ b/connect_freeswitch/deploy/freeswitch/conf/vars.xml
@@ -21,7 +21,7 @@
   <X-PRE-PROCESS cmd="set" data="internal_ssl_enable=false"/>
   <X-PRE-PROCESS cmd="set" data="internal_auth_calls=true"/>
 
-  <X-PRE-PROCESS cmd="set" data="hold_music=silence_stream://0"/>
+  <X-PRE-PROCESS cmd="set" data="hold_music=silence_stream://-1"/>
   <X-PRE-PROCESS cmd="set" data="use_profile=internal"/>
   <!-- Log levels: read from Docker env vars (defaults in Dockerfile) -->
   <X-PRE-PROCESS cmd="env-set" data="core_loglevel=$FS_LOG_LEVEL"/>

--- a/connect_freeswitch/deploy/odoo.conf
+++ b/connect_freeswitch/deploy/odoo.conf
@@ -3,6 +3,5 @@ addons_path = /mnt/extra-addons
 data_dir = /var/lib/odoo
 proxy_mode = True
 http_interface = 0.0.0.0
-without_demo = all
 workers = 2
 admin_passwd = oduist-addons

--- a/connect_freeswitch/models/__init__.py
+++ b/connect_freeswitch/models/__init__.py
@@ -1,4 +1,5 @@
 from . import call
+from . import fs_parking_slot
 from . import fs_template
 from . import endpoint
 from . import exten

--- a/connect_freeswitch/models/call.py
+++ b/connect_freeswitch/models/call.py
@@ -1,8 +1,9 @@
 import logging
 import re
-from odoo import models, api
+from odoo import fields, models, api
 from odoo.exceptions import UserError
 from odoo.addons.connect.models.settings import debug
+from odoo.addons.connect.models.call import CALL_END_STATUSES
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +27,56 @@ HANGUP_CAUSE_MAP = {
 
 class Call(models.Model):
     _inherit = 'connect.call'
+
+    fs_parked_slot = fields.Many2one(
+        'connect.freeswitch.parking.slot',
+        compute='_compute_fs_parked_slot', store=False,
+        string='Parked On')
+
+    def _compute_fs_parked_slot(self):
+        Slot = self.env['connect.freeswitch.parking.slot']
+        for rec in self:
+            rec.fs_parked_slot = Slot.search(
+                [('parked_call', '=', rec.id)], limit=1)
+
+    def action_fs_park(self):
+        """Park this call on the first available slot.
+
+        Raises UserError if no free slot is configured.
+        """
+        self.ensure_one()
+        if self.status in CALL_END_STATUSES:
+            raise UserError("This call is already ended.")
+        if self.fs_parked_slot:
+            raise UserError(
+                "This call is already parked on slot %s."
+                % self.fs_parked_slot.exten)
+        Slot = self.env['connect.freeswitch.parking.slot']
+        slot = Slot.search(
+            [('active', '=', True), ('parked_uuid', '=', False)],
+            order='sequence, exten', limit=1)
+        if not slot:
+            raise UserError(
+                "No free parking slots available. Configure additional "
+                "slots under Connect → Configuration → Parking Slots.")
+        return slot.action_park_call(self.id)
+
+    @api.model
+    def action_fs_park_by_uuid(self, uuid):
+        """Park a call identified by its FreeSWITCH channel UUID.
+
+        Used from the Verto phone widget which knows the Verto callId.
+        """
+        channel = self.env['connect.channel'].search(
+            [('sid', '=', uuid)], limit=1)
+        if not channel or not channel.call:
+            # Channel may not be in DB yet (CDR arrives at hangup). Create a
+            # transient-style lookup: ask FS which call this UUID bridged to,
+            # fall back to no-op.
+            raise UserError(
+                "Call for UUID %s not yet tracked in Odoo. "
+                "Try again in a moment." % uuid)
+        return channel.call.action_fs_park()
 
     @api.model
     def originate_call(self, number, res_model=None, res_id=None):

--- a/connect_freeswitch/models/call.py
+++ b/connect_freeswitch/models/call.py
@@ -62,21 +62,28 @@ class Call(models.Model):
         return slot.action_park_call(self.id)
 
     @api.model
-    def action_fs_park_by_uuid(self, uuid):
-        """Park a call identified by its FreeSWITCH channel UUID.
+    def action_fs_park_by_uuid(self, uuid, slot_id=None):
+        """Park a live call identified by a FreeSWITCH channel UUID.
 
-        Used from the Verto phone widget which knows the Verto callId.
+        Invoked from the Verto phone widget which only knows its local
+        Verto callId (the A-leg UUID). `connect.channel` records are
+        only created at CDR (hangup), so we cannot rely on the DB
+        during an active call — we ask FreeSWITCH directly for the
+        bridged B-leg and caller identity, and park that leg on the
+        requested slot (or the first free slot if none was specified).
         """
-        channel = self.env['connect.channel'].search(
-            [('sid', '=', uuid)], limit=1)
-        if not channel or not channel.call:
-            # Channel may not be in DB yet (CDR arrives at hangup). Create a
-            # transient-style lookup: ask FS which call this UUID bridged to,
-            # fall back to no-op.
-            raise UserError(
-                "Call for UUID %s not yet tracked in Odoo. "
-                "Try again in a moment." % uuid)
-        return channel.call.action_fs_park()
+        Slot = self.env['connect.freeswitch.parking.slot']
+        if slot_id:
+            slot = Slot.browse(int(slot_id))
+            if not slot.exists() or not slot.active:
+                raise UserError("Selected parking slot is not available.")
+        else:
+            slot = Slot.search(
+                [('active', '=', True), ('parked_uuid', '=', False)],
+                order='sequence, exten', limit=1)
+            if not slot:
+                raise UserError("No free parking slots available.")
+        return slot.action_park_channel_uuid(uuid)
 
     @api.model
     def originate_call(self, number, res_model=None, res_id=None):

--- a/connect_freeswitch/models/fs_parking_slot.py
+++ b/connect_freeswitch/models/fs_parking_slot.py
@@ -56,8 +56,12 @@ class FreeSwitchParkingSlot(models.Model):
     def action_park_call(self, call_id=None):
         """Park the given connect.call on this slot.
 
-        Finds the remote leg UUID from the call's channels and issues
-        `uuid_transfer <uuid> 'valet_park default <exten>' inline`.
+        Transfers the remote leg to the slot extension in dialplan
+        context ``default`` so the ``connect_valet_parking_<slot>``
+        extension runs — setting ``api_hangup_hook`` (for the
+        ``released`` webhook) and firing the ``entered`` webhook before
+        ``valet_park``. An ``inline`` transfer would bypass the
+        dialplan and the hooks would never fire.
         """
         self.ensure_one()
         if self.is_occupied:
@@ -74,8 +78,7 @@ class FreeSwitchParkingSlot(models.Model):
                 "Make sure the call is still in progress.")
 
         settings = self.env['connect.settings']
-        args = "{uuid} 'valet_park:{lot} {slot}' inline".format(
-            uuid=uuid, lot=PARKING_LOT_NAME, slot=self.exten)
+        args = "{uuid} {slot} XML default".format(uuid=uuid, slot=self.exten)
         result = settings.freeswitch_api('uuid_transfer', args)
         if not result or str(result).startswith('-ERR'):
             raise UserError(
@@ -116,8 +119,8 @@ class FreeSwitchParkingSlot(models.Model):
         settings = self.env['connect.settings']
         remote_uuid = self._resolve_remote_leg(uuid, settings) or uuid
 
-        args = "{uuid} 'valet_park:{lot} {slot}' inline".format(
-            uuid=remote_uuid, lot=PARKING_LOT_NAME, slot=self.exten)
+        args = "{uuid} {slot} XML default".format(
+            uuid=remote_uuid, slot=self.exten)
         result = settings.freeswitch_api('uuid_transfer', args)
         if not result or str(result).startswith('-ERR'):
             raise UserError(

--- a/connect_freeswitch/models/fs_parking_slot.py
+++ b/connect_freeswitch/models/fs_parking_slot.py
@@ -100,6 +100,55 @@ class FreeSwitchParkingSlot(models.Model):
             },
         }
 
+    def action_park_channel_uuid(self, uuid):
+        """Park the bridged remote leg of a live FS channel on this slot.
+
+        Resolves the remote leg via `uuid_getvar <uuid> bridge_uuid`
+        since `connect.channel` records do not exist until CDR arrives.
+        """
+        self.ensure_one()
+        if self.is_occupied:
+            raise UserError("Slot %s is already occupied." % self.exten)
+        if not uuid:
+            raise UserError("No channel UUID provided.")
+
+        settings = self.env['connect.settings']
+        remote_uuid = self._resolve_remote_leg(uuid, settings) or uuid
+
+        args = "{uuid} 'valet_park {lot} {slot}' inline".format(
+            uuid=remote_uuid, lot=PARKING_LOT_NAME, slot=self.exten)
+        result = settings.freeswitch_api('uuid_transfer', args)
+        if not result or str(result).startswith('-ERR'):
+            raise UserError(
+                "FreeSWITCH rejected the park: %s" % (result or 'no response'))
+
+        caller_number = self._get_channel_var(
+            remote_uuid, 'caller_id_number', settings)
+        caller_name = self._get_channel_var(
+            remote_uuid, 'caller_id_name', settings)
+        channel = self.env['connect.channel'].sudo().search(
+            [('sid', '=', remote_uuid)], limit=1)
+
+        self.sudo().write({
+            'parked_call': channel.call.id if channel and channel.call else False,
+            'parked_uuid': remote_uuid,
+            'parked_at': fields.Datetime.now(),
+            'parked_by_user': self.env.user.id,
+            'parked_caller_number': caller_number or '',
+            'parked_caller_name': caller_name or '',
+        })
+        self._notify_bus()
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': 'Call Parked',
+                'message': 'Call parked on slot %s' % self.exten,
+                'type': 'success',
+                'sticky': False,
+            },
+        }
+
     def action_unpark(self):
         """Retrieve the parked call by originating to the requesting user
         and bridging into the slot's valet extension."""
@@ -207,6 +256,32 @@ class FreeSwitchParkingSlot(models.Model):
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    def _resolve_remote_leg(self, uuid, settings):
+        """Ask FreeSWITCH for the UUID bridged to `uuid`.
+
+        Returns the bridge_uuid if the channel is bridged to another leg
+        (the common case: park the far side, not the widget's own leg).
+        Returns False if the channel has no bridge or FS is unreachable.
+        """
+        bridge = settings.freeswitch_api(
+            'uuid_getvar', '%s bridge_uuid' % uuid)
+        if not bridge:
+            return False
+        bridge = str(bridge).strip()
+        if not bridge or bridge.startswith('-') or bridge == '_undef_':
+            return False
+        return bridge
+
+    def _get_channel_var(self, uuid, var, settings):
+        """Read a channel variable via FS API; empty string on failure."""
+        val = settings.freeswitch_api('uuid_getvar', '%s %s' % (uuid, var))
+        if not val:
+            return ''
+        val = str(val).strip()
+        if val.startswith('-') or val == '_undef_':
+            return ''
+        return val
 
     def _find_remote_leg_uuid(self, call):
         """Return UUID of the channel NOT belonging to the current user.

--- a/connect_freeswitch/models/fs_parking_slot.py
+++ b/connect_freeswitch/models/fs_parking_slot.py
@@ -1,0 +1,249 @@
+import logging
+
+from odoo import api, fields, models, release
+from odoo.exceptions import UserError
+
+logger = logging.getLogger(__name__)
+
+PARKING_LOT_NAME = 'default'
+
+
+class FreeSwitchParkingSlot(models.Model):
+    _name = 'connect.freeswitch.parking.slot'
+    _description = 'FreeSWITCH Parking Slot'
+    _order = 'sequence, exten'
+
+    name = fields.Char(required=True)
+    exten = fields.Char(
+        string='Extension',
+        required=True,
+        index=True,
+        help="Dialable slot number. SIP phones subscribe to <exten>@domain for BLF. "
+             "Dialing this extension parks (if free) or retrieves (if occupied).",
+    )
+    sequence = fields.Integer(default=10)
+    active = fields.Boolean(default=True)
+
+    parked_call = fields.Many2one(
+        'connect.call', readonly=True, ondelete='set null',
+        string='Parked Call')
+    parked_at = fields.Datetime(readonly=True)
+    parked_by_user = fields.Many2one(
+        'res.users', readonly=True, ondelete='set null',
+        string='Parked By')
+    parked_caller_number = fields.Char(readonly=True)
+    parked_caller_name = fields.Char(readonly=True)
+    parked_uuid = fields.Char(readonly=True, string='FreeSWITCH UUID')
+
+    is_occupied = fields.Boolean(
+        compute='_compute_is_occupied', store=True)
+
+    _sql_constraints = [
+        ('exten_unique', 'unique(exten)',
+         'A parking slot with this extension already exists.'),
+    ]
+
+    @api.depends('parked_uuid')
+    def _compute_is_occupied(self):
+        for rec in self:
+            rec.is_occupied = bool(rec.parked_uuid)
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+
+    def action_park_call(self, call_id=None):
+        """Park the given connect.call on this slot.
+
+        Finds the remote leg UUID from the call's channels and issues
+        `uuid_transfer <uuid> 'valet_park default <exten>' inline`.
+        """
+        self.ensure_one()
+        if self.is_occupied:
+            raise UserError(
+                "Slot %s is already occupied." % self.exten)
+        call = self.env['connect.call'].browse(call_id) if call_id else self.env['connect.call']
+        if not call.exists():
+            raise UserError("Call not found.")
+
+        uuid = self._find_remote_leg_uuid(call)
+        if not uuid:
+            raise UserError(
+                "Cannot find an active channel for this call. "
+                "Make sure the call is still in progress.")
+
+        settings = self.env['connect.settings']
+        args = "{uuid} 'valet_park {lot} {slot}' inline".format(
+            uuid=uuid, lot=PARKING_LOT_NAME, slot=self.exten)
+        result = settings.freeswitch_api('uuid_transfer', args)
+        if not result or str(result).startswith('-ERR'):
+            raise UserError(
+                "FreeSWITCH rejected the park: %s" % (result or 'no response'))
+
+        self.sudo().write({
+            'parked_call': call.id,
+            'parked_uuid': uuid,
+            'parked_at': fields.Datetime.now(),
+            'parked_by_user': self.env.user.id,
+            'parked_caller_number': call.caller or '',
+            'parked_caller_name': call.partner.name if call.partner else '',
+        })
+        self._notify_bus()
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': 'Call Parked',
+                'message': 'Call parked on slot %s' % self.exten,
+                'type': 'success',
+                'sticky': False,
+            },
+        }
+
+    def action_unpark(self):
+        """Retrieve the parked call by originating to the requesting user
+        and bridging into the slot's valet extension."""
+        self.ensure_one()
+        if not self.is_occupied:
+            raise UserError("Slot %s is empty." % self.exten)
+
+        user = self.env.user
+        connect_user = self.env['connect.user'].search([
+            ('user', '=', user.id),
+            ('active', '=', True),
+        ], limit=1)
+        if not connect_user:
+            raise UserError("You don't have a Connect user configured.")
+
+        settings = self.env['connect.settings']
+        domain = settings.get_param('freeswitch_domain')
+        if not domain:
+            raise UserError("FreeSWITCH domain is not configured.")
+
+        endpoint_parts = self.env['connect.call']._build_user_bridge(
+            connect_user, domain)
+        if not endpoint_parts:
+            raise UserError("You don't have any ringable endpoints.")
+
+        # Originate: user's devices → dialplan extension <exten> which runs
+        # valet_park default <exten> and retrieves the parked call.
+        cid_name = (self.parked_caller_name or self.parked_caller_number or
+                    'Slot %s' % self.exten).replace("'", "")
+        cid_num = self.parked_caller_number or self.exten
+        variables = [
+            "origination_caller_id_name='{}'".format(cid_name),
+            "origination_caller_id_number={}".format(cid_num),
+            'ignore_early_media=true',
+        ]
+        if connect_user.webrtc_enabled:
+            variables.append('verto_h_auto_answer=true')
+        cmd = '{{{}}}{} {} XML default'.format(
+            ','.join(variables), endpoint_parts, self.exten)
+
+        result = settings.freeswitch_api('originate', cmd)
+        if not result or str(result).startswith('-ERR'):
+            raise UserError(
+                "FreeSWITCH rejected the unpark: %s" % (result or 'no response'))
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': 'Retrieving Call',
+                'message': 'Ringing your phone to pick up slot %s' % self.exten,
+                'type': 'info',
+                'sticky': False,
+            },
+        }
+
+    # ------------------------------------------------------------------
+    # Webhook entry points (called from controllers/freeswitch_parking.py)
+    # ------------------------------------------------------------------
+
+    @api.model
+    def on_parking_entered(self, exten, uuid, caller_number='', caller_name=''):
+        """A channel has entered the valet lot on the given slot."""
+        slot = self.sudo().search([('exten', '=', exten)], limit=1)
+        if not slot:
+            logger.warning("Parking webhook: unknown slot %s", exten)
+            return False
+
+        # Idempotent: if same UUID already recorded, ignore.
+        if slot.parked_uuid == uuid:
+            return True
+
+        channel = self.env['connect.channel'].sudo().search(
+            [('sid', '=', uuid)], limit=1)
+        call = channel.call if channel else self.env['connect.call']
+
+        slot.write({
+            'parked_uuid': uuid,
+            'parked_call': call.id if call else False,
+            'parked_at': fields.Datetime.now(),
+            'parked_caller_number': caller_number or (call.caller if call else ''),
+            'parked_caller_name': caller_name or (call.partner.name if call and call.partner else ''),
+        })
+        slot._notify_bus()
+        return True
+
+    @api.model
+    def on_parking_released(self, exten):
+        """A parked channel left the lot (retrieved or hung up)."""
+        slot = self.sudo().search([('exten', '=', exten)], limit=1)
+        if not slot:
+            return False
+        if not slot.parked_uuid:
+            return True
+        slot.write({
+            'parked_uuid': False,
+            'parked_call': False,
+            'parked_at': False,
+            'parked_by_user': False,
+            'parked_caller_number': False,
+            'parked_caller_name': False,
+        })
+        slot._notify_bus()
+        return True
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _find_remote_leg_uuid(self, call):
+        """Return UUID of the channel NOT belonging to the current user.
+
+        Picks active (not ended) channels first; falls back to the latest
+        channel if none are marked active.
+        """
+        from odoo.addons.connect.models.call import CALL_END_STATUSES
+        me = self.env.user
+        connect_me = self.env['connect.user'].search(
+            [('user', '=', me.id)], limit=1)
+        channels = call.channels.sorted('id', reverse=True)
+        for ch in channels:
+            if ch.status in CALL_END_STATUSES:
+                continue
+            if connect_me and ch.caller_pbx_user == connect_me:
+                continue
+            if ch.sid:
+                return ch.sid
+        # Fallback: any channel with a sid
+        for ch in channels:
+            if ch.sid:
+                return ch.sid
+        return False
+
+    def _notify_bus(self):
+        """Push a reload signal so every Verto widget refreshes its panel."""
+        payload = {
+            'id': self.id,
+            'exten': self.exten,
+            'is_occupied': self.is_occupied,
+        }
+        if release.version_info[0] < 15:
+            import json
+            self.env['bus.bus'].sendone(
+                'connect_actions',
+                json.dumps({'action': 'parking_state_changed', 'payload': payload}))
+        else:
+            self.env['bus.bus']._sendone(
+                'connect_actions', 'parking_state_changed', payload)

--- a/connect_freeswitch/models/fs_parking_slot.py
+++ b/connect_freeswitch/models/fs_parking_slot.py
@@ -73,7 +73,7 @@ class FreeSwitchParkingSlot(models.Model):
                 "Make sure the call is still in progress.")
 
         settings = self.env['connect.settings']
-        args = "{uuid} 'valet_park {lot} {slot}' inline".format(
+        args = "{uuid} 'valet_park:{lot} {slot}' inline".format(
             uuid=uuid, lot=PARKING_LOT_NAME, slot=self.exten)
         result = settings.freeswitch_api('uuid_transfer', args)
         if not result or str(result).startswith('-ERR'):

--- a/connect_freeswitch/models/fs_parking_slot.py
+++ b/connect_freeswitch/models/fs_parking_slot.py
@@ -231,8 +231,10 @@ class FreeSwitchParkingSlot(models.Model):
         cmd = "{{{}}}{} &valet_park({} {})".format(
             ','.join(variables), endpoint_parts,
             PARKING_LOT_NAME, self.exten)
+        logger.info("Unpark slot %s: originate %s", self.exten, cmd)
 
         result = settings.freeswitch_api('originate', cmd)
+        logger.info("Unpark slot %s: FS result: %r", self.exten, result)
         if not result or str(result).startswith('-ERR'):
             raise UserError(
                 "FreeSWITCH rejected the unpark: %s" % (result or 'no response'))

--- a/connect_freeswitch/models/fs_parking_slot.py
+++ b/connect_freeswitch/models/fs_parking_slot.py
@@ -115,7 +115,7 @@ class FreeSwitchParkingSlot(models.Model):
         settings = self.env['connect.settings']
         remote_uuid = self._resolve_remote_leg(uuid, settings) or uuid
 
-        args = "{uuid} 'valet_park {lot} {slot}' inline".format(
+        args = "{uuid} 'valet_park:{lot} {slot}' inline".format(
             uuid=remote_uuid, lot=PARKING_LOT_NAME, slot=self.exten)
         result = settings.freeswitch_api('uuid_transfer', args)
         if not result or str(result).startswith('-ERR'):

--- a/connect_freeswitch/models/fs_parking_slot.py
+++ b/connect_freeswitch/models/fs_parking_slot.py
@@ -149,6 +149,50 @@ class FreeSwitchParkingSlot(models.Model):
             },
         }
 
+    def action_reset(self):
+        """Forcefully clear slot state.
+
+        Used when Odoo and FreeSWITCH fall out of sync (e.g. a park
+        transfer failed after we optimistically wrote the slot). Does
+        not touch FS — the channel, if any, is untouched.
+        """
+        for rec in self:
+            rec.sudo().write({
+                'parked_uuid': False,
+                'parked_call': False,
+                'parked_at': False,
+                'parked_by_user': False,
+                'parked_caller_number': False,
+                'parked_caller_name': False,
+            })
+            rec._notify_bus()
+        return True
+
+    def action_sync_from_fs(self):
+        """Drop state for slots whose parked UUID no longer exists in FS."""
+        settings = self.env['connect.settings']
+        targets = self or self.sudo().search(
+            [('active', '=', True), ('parked_uuid', '!=', False)])
+        cleared = 0
+        for slot in targets:
+            if not slot.parked_uuid:
+                continue
+            alive = settings.freeswitch_api('uuid_exists', slot.parked_uuid)
+            if not alive or str(alive).strip().lower() != 'true':
+                slot.action_reset()
+                cleared += 1
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': 'Parking Sync',
+                'message': ('%d stale slot(s) cleared.' % cleared
+                            if cleared else 'All slots in sync.'),
+                'type': 'info',
+                'sticky': False,
+            },
+        }
+
     def action_unpark(self):
         """Retrieve the parked call by originating to the requesting user
         and bridging into the slot's valet extension."""
@@ -174,8 +218,6 @@ class FreeSwitchParkingSlot(models.Model):
         if not endpoint_parts:
             raise UserError("You don't have any ringable endpoints.")
 
-        # Originate: user's devices → dialplan extension <exten> which runs
-        # valet_park default <exten> and retrieves the parked call.
         cid_name = (self.parked_caller_name or self.parked_caller_number or
                     'Slot %s' % self.exten).replace("'", "")
         cid_num = self.parked_caller_number or self.exten
@@ -186,8 +228,9 @@ class FreeSwitchParkingSlot(models.Model):
         ]
         if connect_user.webrtc_enabled:
             variables.append('verto_h_auto_answer=true')
-        cmd = '{{{}}}{} {} XML default'.format(
-            ','.join(variables), endpoint_parts, self.exten)
+        cmd = "{{{}}}{} &valet_park({} {})".format(
+            ','.join(variables), endpoint_parts,
+            PARKING_LOT_NAME, self.exten)
 
         result = settings.freeswitch_api('originate', cmd)
         if not result or str(result).startswith('-ERR'):

--- a/connect_freeswitch/models/fs_parking_slot.py
+++ b/connect_freeswitch/models/fs_parking_slot.py
@@ -228,7 +228,7 @@ class FreeSwitchParkingSlot(models.Model):
         ]
         if connect_user.webrtc_enabled:
             variables.append('verto_h_auto_answer=true')
-        cmd = "{{{}}}{} &valet_park({} {})".format(
+        cmd = "{{{}}}{} '&valet_park({} {})'".format(
             ','.join(variables), endpoint_parts,
             PARKING_LOT_NAME, self.exten)
         logger.info("Unpark slot %s: originate %s", self.exten, cmd)

--- a/connect_freeswitch/models/fs_parking_slot.py
+++ b/connect_freeswitch/models/fs_parking_slot.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from odoo import api, fields, models, release
 from odoo.exceptions import UserError
@@ -169,16 +170,22 @@ class FreeSwitchParkingSlot(models.Model):
         return True
 
     def action_sync_from_fs(self):
-        """Drop state for slots whose parked UUID no longer exists in FS."""
+        """Drop state for slots not actually parked in FreeSWITCH.
+
+        Queries `valet_info <lot>` for the authoritative list of
+        currently-parked UUIDs. `uuid_exists` is not enough: after
+        retrieval the channel is still alive (bridged to the new leg)
+        but no longer in the lot, so the slot must be cleared.
+        """
         settings = self.env['connect.settings']
+        live = self._fetch_parked_uuids(settings)
         targets = self or self.sudo().search(
             [('active', '=', True), ('parked_uuid', '!=', False)])
         cleared = 0
         for slot in targets:
             if not slot.parked_uuid:
                 continue
-            alive = settings.freeswitch_api('uuid_exists', slot.parked_uuid)
-            if not alive or str(alive).strip().lower() != 'true':
+            if slot.parked_uuid not in live:
                 slot.action_reset()
                 cleared += 1
         return {
@@ -301,6 +308,27 @@ class FreeSwitchParkingSlot(models.Model):
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    def _fetch_parked_uuids(self, settings):
+        """Return the set of UUIDs currently parked in our lot.
+
+        `valet_info <lot>` returns XML like::
+
+            <lots>
+              <lot name="default">
+                <extension uuid="...">705</extension>
+              </lot>
+            </lots>
+
+        Empty lot → no <extension> elements; FS unreachable → empty set
+        (caller must interpret this as "don't know, leave Odoo state as is"
+        — but action_sync_from_fs intentionally treats empty as "clear",
+        matching what operators expect when FS has been restarted).
+        """
+        raw = settings.freeswitch_api('valet_info', PARKING_LOT_NAME)
+        if not raw:
+            return set()
+        return set(re.findall(r'uuid="([^"]+)"', str(raw)))
 
     def _resolve_remote_leg(self, uuid, settings):
         """Ask FreeSWITCH for the UUID bridged to `uuid`.

--- a/connect_freeswitch/security/access_rules.xml
+++ b/connect_freeswitch/security/access_rules.xml
@@ -94,4 +94,35 @@
         <field name="perm_unlink" eval="False"/>
     </record>
 
+    <!-- connect.freeswitch.parking.slot access rules -->
+    <record id="access_freeswitch_parking_slot_admin" model="ir.model.access">
+        <field name="name">connect.freeswitch.parking.slot admin</field>
+        <field name="model_id" ref="model_connect_freeswitch_parking_slot"/>
+        <field name="group_id" ref="connect.group_admin"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+
+    <record id="access_freeswitch_parking_slot_user" model="ir.model.access">
+        <field name="name">connect.freeswitch.parking.slot user</field>
+        <field name="model_id" ref="model_connect_freeswitch_parking_slot"/>
+        <field name="group_id" ref="connect.group_user"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+
+    <record id="access_freeswitch_parking_slot_webhook" model="ir.model.access">
+        <field name="name">connect.freeswitch.parking.slot webhook</field>
+        <field name="model_id" ref="model_connect_freeswitch_parking_slot"/>
+        <field name="group_id" ref="connect.group_webhook"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+
 </odoo>

--- a/connect_freeswitch/static/src/css/phone_systray.css
+++ b/connect_freeswitch/static/src/css/phone_systray.css
@@ -168,3 +168,143 @@
 .o_phone_dialpad:has(.o_phone_answer_btn) .o_phone_incoming_info {
     background: #d4edda;
 }
+
+/* Panel container with tabs (Dialer / Parking) */
+.o_phone_mode_dropdown .o_phone_panel_container {
+    position: fixed;
+    top: 50px;
+    right: 16px;
+    z-index: 1051;
+    width: 320px;
+    background: white;
+    border: 1px solid #dee2e6;
+    border-radius: 8px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+    overflow: hidden;
+}
+
+.o_phone_mode_float .o_phone_panel_container {
+    width: 320px;
+    background: white;
+    border: 1px solid #dee2e6;
+    border-radius: 8px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+    overflow: hidden;
+}
+
+.o_phone_panel_tabs {
+    display: flex;
+    border-bottom: 1px solid #dee2e6;
+}
+
+.o_phone_panel_tab {
+    flex: 1;
+    background: #f8f9fa;
+    border: none;
+    padding: 10px;
+    font-size: 14px;
+    font-weight: 500;
+    color: #495057;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.o_phone_panel_tab:hover {
+    background: #e9ecef;
+}
+
+.o_phone_panel_tab.active {
+    background: white;
+    color: #212529;
+    border-bottom: 2px solid #0d6efd;
+}
+
+.o_phone_panel_body .o_phone_dialpad {
+    position: static;
+    border: none;
+    box-shadow: none;
+    padding: 15px;
+    width: 100%;
+}
+
+/* Parking panel */
+.o_parking_panel {
+    padding: 15px;
+}
+
+.o_parking_hint {
+    font-size: 12px;
+    color: #495057;
+    margin-bottom: 10px;
+    text-align: center;
+}
+
+.o_parking_hint_muted {
+    color: #6c757d;
+}
+
+.o_parking_grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+}
+
+.o_parking_slot {
+    border: 1px solid #dee2e6;
+    border-radius: 8px;
+    padding: 10px;
+    cursor: pointer;
+    background: #f8f9fa;
+    transition: background 0.15s, border-color 0.15s;
+    text-align: center;
+}
+
+.o_parking_slot:hover {
+    background: #e9ecef;
+}
+
+.o_parking_slot_exten {
+    font-size: 18px;
+    font-weight: 700;
+}
+
+.o_parking_slot_label {
+    font-size: 12px;
+    margin: 4px 0;
+    min-height: 1em;
+}
+
+.o_parking_slot_name {
+    font-size: 10px;
+    color: #6c757d;
+}
+
+.o_parking_slot_occupied {
+    background: #fff3cd;
+    border-color: #ffc107;
+}
+
+.o_parking_slot_occupied:hover {
+    background: #ffe69c;
+}
+
+.o_parking_slot_parkable {
+    background: #d1e7dd;
+    border-color: #198754;
+}
+
+.o_parking_slot_parkable:hover {
+    background: #a3cfbb;
+}
+
+.o_parking_slot_idle {
+    cursor: default;
+    opacity: 0.7;
+}
+
+.o_parking_empty {
+    text-align: center;
+    color: #6c757d;
+    font-size: 13px;
+    padding: 20px;
+}

--- a/connect_freeswitch/static/src/js/parking_panel.js
+++ b/connect_freeswitch/static/src/js/parking_panel.js
@@ -1,0 +1,134 @@
+/** @odoo-module **/
+
+import { Component, useState, onWillStart, onMounted, onWillUnmount } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+
+
+export class ParkingPanel extends Component {
+    static template = "connect_freeswitch.ParkingPanel";
+    static props = {
+        bus: Object,
+        vertoClient: { optional: true },
+        callState: String,
+    };
+
+    setup() {
+        this.orm = useService("orm");
+        this.notification = useService("notification");
+        this.state = useState({
+            slots: [],
+            loading: false,
+        });
+
+        this._onParkingChanged = () => this._refreshSlots();
+
+        onWillStart(async () => {
+            await this._refreshSlots();
+        });
+
+        onMounted(() => {
+            this.props.bus.addEventListener("parkingStateChanged", this._onParkingChanged);
+        });
+
+        onWillUnmount(() => {
+            this.props.bus.removeEventListener("parkingStateChanged", this._onParkingChanged);
+        });
+    }
+
+    async _refreshSlots() {
+        this.state.loading = true;
+        try {
+            const slots = await this.orm.searchRead(
+                "connect.freeswitch.parking.slot",
+                [["active", "=", true]],
+                [
+                    "id", "name", "exten", "sequence",
+                    "is_occupied", "parked_caller_number",
+                    "parked_caller_name", "parked_at",
+                ],
+                { order: "sequence, exten" },
+            );
+            this.state.slots = slots;
+        } catch (error) {
+            console.error("[Parking] Failed to load slots:", error);
+        } finally {
+            this.state.loading = false;
+        }
+    }
+
+    get hasActiveCall() {
+        return this.props.callState === "active";
+    }
+
+    async onSlotClick(slot) {
+        if (slot.is_occupied) {
+            await this._unpark(slot);
+        } else if (this.hasActiveCall) {
+            await this._park(slot);
+        } else {
+            this.notification.add(
+                "No active call to park. Connect first, then press Park on a free slot.",
+                { type: "info" },
+            );
+        }
+    }
+
+    async _park(slot) {
+        const uuid = this.props.vertoClient?.currentCall?.callId;
+        if (!uuid) {
+            this.notification.add("No active call UUID found.", { type: "warning" });
+            return;
+        }
+        try {
+            const action = await this.orm.call(
+                "connect.call", "action_fs_park_by_uuid", [uuid],
+            );
+            if (action && action.params && action.params.message) {
+                this.notification.add(action.params.message, {
+                    type: action.params.type || "success",
+                    title: action.params.title,
+                });
+            }
+        } catch (error) {
+            this._notifyError(error);
+        }
+    }
+
+    async _unpark(slot) {
+        try {
+            const action = await this.orm.call(
+                "connect.freeswitch.parking.slot", "action_unpark", [[slot.id]],
+            );
+            if (action && action.params && action.params.message) {
+                this.notification.add(action.params.message, {
+                    type: action.params.type || "info",
+                    title: action.params.title,
+                });
+            }
+        } catch (error) {
+            this._notifyError(error);
+        }
+    }
+
+    _notifyError(error) {
+        const msg = error?.data?.message || error?.message || "Operation failed.";
+        this.notification.add(msg, { type: "danger" });
+    }
+
+    slotClass(slot) {
+        const base = "o_parking_slot";
+        if (slot.is_occupied) return base + " o_parking_slot_occupied";
+        if (this.hasActiveCall) return base + " o_parking_slot_parkable";
+        return base + " o_parking_slot_idle";
+    }
+
+    slotLabel(slot) {
+        if (slot.is_occupied) {
+            if (slot.parked_caller_name && slot.parked_caller_number) {
+                return `${slot.parked_caller_name} (${slot.parked_caller_number})`;
+            }
+            return slot.parked_caller_name || slot.parked_caller_number || "Parked";
+        }
+        return "Free";
+    }
+}

--- a/connect_freeswitch/static/src/js/parking_panel.js
+++ b/connect_freeswitch/static/src/js/parking_panel.js
@@ -81,7 +81,7 @@ export class ParkingPanel extends Component {
         }
         try {
             const action = await this.orm.call(
-                "connect.call", "action_fs_park_by_uuid", [uuid],
+                "connect.call", "action_fs_park_by_uuid", [uuid, slot.id],
             );
             if (action && action.params && action.params.message) {
                 this.notification.add(action.params.message, {

--- a/connect_freeswitch/static/src/js/phone_panel.js
+++ b/connect_freeswitch/static/src/js/phone_panel.js
@@ -2,11 +2,12 @@
 
 import { Component, useState, onMounted, onWillUnmount } from "@odoo/owl";
 import { PhoneDialpad } from "./phone_systray";
+import { ParkingPanel } from "./parking_panel";
 
 
 export class PhonePanel extends Component {
     static template = "connect_freeswitch.PhonePanel";
-    static components = { PhoneDialpad };
+    static components = { PhoneDialpad, ParkingPanel };
     static props = {
         bus: Object,
         displayMode: String,
@@ -17,6 +18,7 @@ export class PhonePanel extends Component {
     setup() {
         this.state = useState({
             showDialpad: false,
+            activeTab: "dialer",
             vertoState: "disconnected",
             callState: "idle",
             callerName: "",
@@ -75,5 +77,9 @@ export class PhonePanel extends Component {
 
     closeDialpad() {
         this.state.showDialpad = false;
+    }
+
+    setTab(tab) {
+        this.state.activeTab = tab;
     }
 }

--- a/connect_freeswitch/static/src/js/phone_service.js
+++ b/connect_freeswitch/static/src/js/phone_service.js
@@ -8,9 +8,9 @@ import { VertoClient } from "./verto_client";
 
 
 export const phoneService = {
-    dependencies: ["orm"],
+    dependencies: ["orm", "bus_service"],
 
-    async start(env, { orm }) {
+    async start(env, { orm, bus_service }) {
         const pathname = document.location.pathname;
         if (!pathname.includes("/odoo")) {
             return { enabled: false };
@@ -146,6 +146,12 @@ export const phoneService = {
         registry.category("main_components").add("connect_freeswitch.PhonePanel", {
             Component: PhonePanel,
             props: { bus, displayMode, getVertoClient: () => vertoClient, connect },
+        });
+
+        // Subscribe to Odoo bus channel for server-pushed events (e.g. parking).
+        bus_service.addChannel("connect_actions");
+        bus_service.subscribe("parking_state_changed", (payload) => {
+            bus.trigger("parkingStateChanged", payload);
         });
 
         // Connect immediately

--- a/connect_freeswitch/static/src/xml/parking_panel.xml
+++ b/connect_freeswitch/static/src/xml/parking_panel.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="connect_freeswitch.ParkingPanel">
+        <div class="o_parking_panel">
+            <div class="o_parking_hint" t-if="hasActiveCall">
+                Click an empty slot to park the current call.
+            </div>
+            <div class="o_parking_hint o_parking_hint_muted" t-if="!hasActiveCall">
+                No active call. Click an occupied slot to retrieve it.
+            </div>
+            <div class="o_parking_grid">
+                <t t-foreach="state.slots" t-as="slot" t-key="slot.id">
+                    <div t-att-class="slotClass(slot)" t-on-click="() => this.onSlotClick(slot)">
+                        <div class="o_parking_slot_exten">
+                            <t t-esc="slot.exten"/>
+                        </div>
+                        <div class="o_parking_slot_label" t-esc="slotLabel(slot)"/>
+                        <div class="o_parking_slot_name" t-esc="slot.name"/>
+                    </div>
+                </t>
+            </div>
+            <div class="o_parking_empty" t-if="!state.slots.length and !state.loading">
+                No parking slots configured.
+            </div>
+        </div>
+    </t>
+
+</templates>

--- a/connect_freeswitch/static/src/xml/phone_systray.xml
+++ b/connect_freeswitch/static/src/xml/phone_systray.xml
@@ -11,19 +11,40 @@
 
     <t t-name="connect_freeswitch.PhonePanel">
         <div t-att-class="modeClass" t-if="state.showDialpad">
-            <PhoneDialpad
-                close.bind="closeDialpad"
-                vertoClient="props.getVertoClient()"
-                state="state.vertoState"
-                callState="state.callState"
-                callerName="state.callerName"
-                callerNumber="state.callerNumber"
-            />
+            <div class="o_phone_dialpad_overlay" t-on-click="closeDialpad"/>
+            <div class="o_phone_panel_container">
+                <div class="o_phone_panel_tabs">
+                    <button t-att-class="'o_phone_panel_tab ' + (state.activeTab === 'dialer' ? 'active' : '')"
+                            t-on-click="() => this.setTab('dialer')">
+                        <i class="fa fa-phone"/> Dialer
+                    </button>
+                    <button t-att-class="'o_phone_panel_tab ' + (state.activeTab === 'parking' ? 'active' : '')"
+                            t-on-click="() => this.setTab('parking')">
+                        <i class="fa fa-parking"/> Parking
+                    </button>
+                </div>
+                <div class="o_phone_panel_body" t-if="state.activeTab === 'dialer'">
+                    <PhoneDialpad
+                        close.bind="closeDialpad"
+                        vertoClient="props.getVertoClient()"
+                        state="state.vertoState"
+                        callState="state.callState"
+                        callerName="state.callerName"
+                        callerNumber="state.callerNumber"
+                    />
+                </div>
+                <div class="o_phone_panel_body" t-if="state.activeTab === 'parking'">
+                    <ParkingPanel
+                        bus="props.bus"
+                        vertoClient="props.getVertoClient()"
+                        callState="state.callState"
+                    />
+                </div>
+            </div>
         </div>
     </t>
 
     <t t-name="connect_freeswitch.PhoneDialpad">
-        <div class="o_phone_dialpad_overlay" t-on-click="props.close"/>
         <div class="o_phone_dialpad">
             <div class="o_phone_dialpad_header">
                 <span class="o_phone_dialpad_title">Phone</span>

--- a/connect_freeswitch/views/call_views.xml
+++ b/connect_freeswitch/views/call_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_connect_call_form_inherit_parking" model="ir.ui.view">
+        <field name="name">connect.call.form.parking</field>
+        <field name="model">connect.call</field>
+        <field name="inherit_id" ref="connect.view_connect_call_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//header" position="inside">
+                <button name="action_fs_park"
+                        type="object"
+                        string="Park"
+                        class="btn-secondary"
+                        invisible="status in ('completed','busy','failed','no-answer','canceled') or fs_parked_slot"/>
+                <field name="fs_parked_slot"
+                       readonly="1"
+                       widget="many2one_tag"
+                       invisible="not fs_parked_slot"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/connect_freeswitch/views/fs_parking_slot_views.xml
+++ b/connect_freeswitch/views/fs_parking_slot_views.xml
@@ -30,6 +30,14 @@
                             string="Unpark"
                             class="btn-primary"
                             invisible="not is_occupied"/>
+                    <button name="action_reset"
+                            type="object"
+                            string="Reset Slot"
+                            confirm="Clear slot state without touching FreeSWITCH?"
+                            invisible="not is_occupied"/>
+                    <button name="action_sync_from_fs"
+                            type="object"
+                            string="Sync from FreeSWITCH"/>
                 </header>
                 <sheet>
                     <div class="oe_title">
@@ -55,6 +63,24 @@
                 </sheet>
             </form>
         </field>
+    </record>
+
+    <record id="action_fs_parking_slot_sync" model="ir.actions.server">
+        <field name="name">Sync from FreeSWITCH</field>
+        <field name="model_id" ref="model_connect_freeswitch_parking_slot"/>
+        <field name="binding_model_id" ref="model_connect_freeswitch_parking_slot"/>
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">action = records.action_sync_from_fs()</field>
+    </record>
+
+    <record id="action_fs_parking_slot_reset" model="ir.actions.server">
+        <field name="name">Reset Slot State</field>
+        <field name="model_id" ref="model_connect_freeswitch_parking_slot"/>
+        <field name="binding_model_id" ref="model_connect_freeswitch_parking_slot"/>
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">records.action_reset()</field>
     </record>
 
     <record id="action_fs_parking_slot" model="ir.actions.act_window">

--- a/connect_freeswitch/views/fs_parking_slot_views.xml
+++ b/connect_freeswitch/views/fs_parking_slot_views.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_fs_parking_slot_tree" model="ir.ui.view">
+        <field name="name">connect.freeswitch.parking.slot.tree</field>
+        <field name="model">connect.freeswitch.parking.slot</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="sequence" widget="handle"/>
+                <field name="exten"/>
+                <field name="name"/>
+                <field name="is_occupied"/>
+                <field name="parked_caller_number"/>
+                <field name="parked_caller_name"/>
+                <field name="parked_by_user"/>
+                <field name="parked_at"/>
+                <field name="active"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="view_fs_parking_slot_form" model="ir.ui.view">
+        <field name="name">connect.freeswitch.parking.slot.form</field>
+        <field name="model">connect.freeswitch.parking.slot</field>
+        <field name="arch" type="xml">
+            <form>
+                <header>
+                    <button name="action_unpark"
+                            type="object"
+                            string="Unpark"
+                            class="btn-primary"
+                            invisible="not is_occupied"/>
+                </header>
+                <sheet>
+                    <div class="oe_title">
+                        <h1><field name="name" placeholder="Slot 701"/></h1>
+                    </div>
+                    <group>
+                        <group string="Configuration">
+                            <field name="exten"/>
+                            <field name="sequence"/>
+                            <field name="active"/>
+                        </group>
+                        <group string="Currently Parked"
+                               invisible="not is_occupied">
+                            <field name="is_occupied"/>
+                            <field name="parked_call"/>
+                            <field name="parked_caller_number"/>
+                            <field name="parked_caller_name"/>
+                            <field name="parked_by_user"/>
+                            <field name="parked_at"/>
+                            <field name="parked_uuid"/>
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_fs_parking_slot" model="ir.actions.act_window">
+        <field name="name">Parking Slots</field>
+        <field name="res_model">connect.freeswitch.parking.slot</field>
+        <field name="view_mode">list,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">Add a parking slot</p>
+            <p>Parking slots let users put active calls on hold and retrieve them
+               from any phone by dialing the slot extension. BLF-capable SIP phones
+               show occupied/free state on DSS keys subscribed to the slot.</p>
+        </field>
+    </record>
+
+    <menuitem id="menu_fs_parking_slot"
+              name="Parking Slots"
+              parent="connect.menu_connect_pbx"
+              action="action_fs_parking_slot"
+              sequence="80"
+              groups="connect.group_admin"/>
+
+</odoo>

--- a/connect_twilio/__manifest__.py
+++ b/connect_twilio/__manifest__.py
@@ -1,6 +1,7 @@
 {
     'name': 'Oduist Connect Twilio',
     'version': '19.0.1.1.0',
+    'author': 'Oduist',
     'category': 'Phone',
     'summary': 'Twilio integration for Oduist Connect',
     'depends': ['connect'],

--- a/docs/admin/parking.md
+++ b/docs/admin/parking.md
@@ -1,0 +1,92 @@
+# Call Parking Setup
+
+Call parking is provided by FreeSWITCH's `mod_valet_parking`. It works
+out of the box after upgrading the `connect_freeswitch` module to
+`19.0.1.7.0` or later — no manual FreeSWITCH configuration is needed.
+
+## What's wired up automatically
+
+- **`mod_valet_parking` module** is loaded at FreeSWITCH start
+  (`autoload_configs/modules.conf.xml`).
+- **Presence / BLF support** is enabled on the sofia profile:
+  `manage-presence=true`, `send-presence-on-register=first-register`,
+  `presence-hosts=<fs_domain>,<local_ip>`. These are emitted by the
+  `fs_template_config_sofia` Jinja2 template, so an upgrade of the
+  module is enough to pick them up.
+- **Parking dialplan** is served dynamically by the Odoo `mod_xml_curl`
+  handler. When a SIP phone dials a parking slot extension, Odoo
+  renders the `dialplan_valet_parking` template on the fly and returns
+  it. This means you never need to restart FreeSWITCH to add or remove
+  slots.
+- **Six default slots** (701–706) are created on first install from
+  `data/parking_slots.xml` (`noupdate="1"` — changes survive module
+  upgrades).
+
+## Managing slots
+
+Navigate to **Admin → PBX → Parking Slots**. Admins can:
+
+- Create new slots with any dialable extension.
+- Rename, re-order (`sequence` field) or deactivate slots.
+- Inspect the currently parked call directly on the slot form, with an
+  **Unpark** button for debug.
+
+Each slot extension must be **unique**. The frontend tab shows slots
+in `sequence`, then `exten` order; keep the total count small (≤ 8)
+so the grid fits without scrolling.
+
+## BLF on hardware SIP phones
+
+On a phone that supports BLF, programme one DSS button per slot with
+the following SIP SUBSCRIBE target:
+
+```
+<slot-exten>@<fs_domain>
+```
+
+For example, for slot `701` on a FreeSWITCH whose `freeswitch_domain`
+is `pbx.example.com`, the BLF URI is `701@pbx.example.com`. The lamp
+turns on when the slot is occupied and off when empty. Pressing the
+key dials the slot extension, which parks (if empty) or retrieves (if
+occupied).
+
+## Webhook endpoint
+
+When a channel enters or leaves a slot, FreeSWITCH posts to Odoo:
+
+- `GET /freeswitch/webhook/parking?event=entered&slot=<s>&uuid=<u>&caller_number=<n>&caller_name=<name>`
+- `GET /freeswitch/webhook/parking?event=released&slot=<s>`
+
+These are idempotent; replays are safe. The base URL is taken from
+`web.base.url`, so ensure that system parameter is set to the
+externally reachable Odoo URL — the same constraint that already
+applies to call recording (ADR-005).
+
+## Verifying the installation
+
+Inside the FreeSWITCH container:
+
+```bash
+fs_cli -x "module_exists mod_valet_parking"      # → true
+fs_cli -x "sofia status profile internal"        # PRESENCE-HOSTS present?
+fs_cli -x "valet_info default"                   # list occupied slots
+```
+
+End-to-end test:
+
+1. Open the Verto widget in a browser, originate a call to a second
+   extension, answer it.
+2. In the Parking tab click slot 701 — the slot card shows the caller's
+   number. On a BLF-enabled SIP phone subscribed to `701@domain`, the
+   lamp is now red.
+3. Pick up the call from the SIP phone by pressing the DSS key, or
+   click the occupied slot card in another browser session.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| BLF lamp never lights up | Phone not subscribed to `<slot>@<fs_domain>` or sofia profile missing presence params — reload profile and re-register the phone |
+| Parked call card stays empty in the widget | Webhook URL unreachable from the FreeSWITCH container — check that `web.base.url` resolves from inside the FS container |
+| "Slot is already occupied" when parking | Previous park did not get a `released` event; check FreeSWITCH logs and retrieve the slot manually via **Unpark** in the slot form |
+| `connect.call` form shows no Park button | The call's `status` is already in an end state (`completed`/`failed`/…) or the slot is already linked |

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -31,10 +31,12 @@ nav:
       - Core Configuration: admin/core-setup.md
       - Twilio Integration: admin/twilio-setup.md
       - FreeSWITCH Integration: admin/freeswitch-setup.md
+      - Call Parking: admin/parking.md
       - Security: admin/security.md
   - User Guide:
       - Getting Started: user/getting-started.md
       - Making and Receiving Calls: user/calls.md
+      - Call Parking: user/parking.md
       - Messages (SMS & WhatsApp): user/messages.md
       - Recordings & Transcriptions: user/recordings.md
       - Call Flows (IVR): user/callflows.md

--- a/docs/user/parking.md
+++ b/docs/user/parking.md
@@ -1,0 +1,56 @@
+# Call Parking
+
+Parking is a way to put an active call on hold at a shared slot that any
+other operator can pick up from their own phone. It's different from a
+private hold because any extension in the office can retrieve the
+parked call.
+
+## Parking a call
+
+You can park a call from three places:
+
+### From the Verto phone widget
+
+1. While connected, open the phone widget and switch to the **Parking**
+   tab.
+2. Click any **empty** slot (green). The far end is moved to that slot
+   and the slot card starts showing the caller's number / name.
+3. Announce the slot over a loudspeaker or messenger — "Call for John on
+   701".
+
+### From the `connect.call` form
+
+1. Open the active call record in Odoo.
+2. Click **Park** in the header. The call goes into the first free
+   slot; the slot number is shown next to the call status.
+
+### From a hardware SIP phone
+
+If you have a DSS (speed-dial) button programmed for a slot extension
+(e.g. `701`), press it while the call is active to park the far side on
+that slot. The button's BLF lamp turns red / busy to indicate the slot
+is occupied.
+
+## Retrieving a parked call
+
+Parked calls can be retrieved from the same three places:
+
+- **Verto widget → Parking tab:** click the occupied slot (yellow) — your
+  phone rings and, when you answer, you're connected to the parked
+  party.
+- **Hardware SIP phone:** press the DSS button for the occupied slot.
+  Your phone is called back and bridged to the parked party.
+- **Admin form (debug):** open the slot record under
+  *Admin → PBX → Parking Slots* and press **Unpark**.
+
+## Tips
+
+- Each slot's BLF lamp updates in near real time for every subscribing
+  phone in the office, so anyone can tell at a glance which slots are
+  busy.
+- If no one retrieves a parked call, `mod_valet_parking`'s default
+  behaviour is to keep the caller on hold indefinitely. Operators
+  should treat parking as a short-lived hand-off, not as a parking lot
+  for abandoned calls.
+- The number of slots is set by the admin. The default is six (701–706),
+  sized to fit the Parking tab without scrolling.

--- a/odoo.conf
+++ b/odoo.conf
@@ -1,7 +1,6 @@
 [options]
 addons_path = /mnt/extra-addons
 list_db = False
-without_demo = all
 max_cron_threads = 1
 limit_time_cpu = 600
 limit_time_real = 1200

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -440,4 +440,12 @@ connect_twilio/                       # Twilio integration
 
 connect_freeswitch/                   # FreeSWITCH integration (existing)
   (follows same _inherit pattern)
+  models/
+    fs_parking_slot.py                # connect.freeswitch.parking.slot
+    call.py                           # _inherit; adds fs_parked_slot + Park actions
+  controllers/
+    freeswitch_parking.py             # GET /freeswitch/webhook/parking?event=…
+  static/src/
+    js/parking_panel.js               # OWL component for the Verto Parking tab
+    xml/parking_panel.xml             # template
 ```

--- a/specs/decisions/012-call-parking.md
+++ b/specs/decisions/012-call-parking.md
@@ -1,0 +1,122 @@
+# ADR-012: Call Parking (Valet) with BLF and Verto Parking Tab
+
+**Date:** 2026-04-21
+**Status:** Accepted
+
+## Problem
+
+Operators need standard office-grade call parking that works consistently across hardware SIP phones and the browser Verto widget:
+
+1. On a **hardware SIP phone** a parked slot should appear on a DSS (speed-dial) button, where the same extension dials to both park (when empty) and retrieve (when occupied), with a **BLF lamp** that reflects the slot's busy state.
+2. In the **browser Verto widget** operators want a dedicated Parking tab alongside the dialer, with one card per slot showing the parked caller's name and number, and Park / Pick-up buttons.
+3. From the `connect.call` form the current call should be parkable with one click into the first free slot.
+4. The number of slots is small and admin-configurable (default 6, visually fitting into the widget).
+
+## Options Considered
+
+### Parking engine
+- **A) `mod_valet_parking`** — built-in FreeSWITCH module that stores channels in a named lot with named slots, plus presence/BLF support.
+- **B) `mod_fifo`** — queue semantics, not slot semantics; no BLF per position.
+- **C) Custom uuid_park + in-memory map** — reinvents what valet_parking already does.
+
+### Configuration model
+- **A) Fixed extension range** (e.g. `701–799`) as a setting — trivial to wire up, but no place to hold per-slot state (who parked, caller name) and no way to rename or deactivate a single slot.
+- **B) `connect.freeswitch.parking.slot` records** — one DB record per slot. CRUD via Odoo, holds live state, feeds the frontend directly via `search_read`.
+
+### Retrieval / unpark
+- **A) Originate to user's endpoints → dialplan extension** that runs `valet_park <lot> <slot>` — identical code path for DSS-retrieval and Pick-up click.
+- **B) `uuid_bridge` between caller's active channel and the parked channel** — requires knowing the user's current channel UUID; tricky when user has no active call.
+
+### Synchronising state with Odoo
+- **A) Dialplan webhook** (`curl` on park entry, `api_hangup_hook` on exit) — push-based, near-zero latency, idempotent.
+- **B) ESL subscription + background poll** — more moving parts, stateful, harder to operate.
+
+## Chosen Approach
+
+| Area | Choice |
+|------|--------|
+| Engine | `mod_valet_parking`, single lot `default` |
+| Slots | Model `connect.freeswitch.parking.slot` (one record per slot) |
+| BLF | `manage-presence=true` + `presence-hosts` on sofia profile; dialplan sets `presence_id=<slot>@<domain>` before `valet_park` |
+| Park action | `uuid_transfer <remote-leg-uuid> 'valet_park default <slot>' inline` via XML-RPC `freeswitch_api` |
+| Retrieve action | `originate <user-endpoints> <slot> XML default`; same dialplan extension handles DSS-button and Pick-up |
+| State sync | Two webhooks (`entered` / `released`) on the same URL, idempotent; fired by dialplan `curl` and `api_hangup_hook` |
+| Frontend bridge | Server emits `parking_state_changed` on bus channel `connect_actions`; the phone service forwards to the Verto widget's local EventBus |
+
+## Key Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Slot model (not a range) | Per-slot state (`parked_call`, `parked_caller_*`) is a first-class field; admin can CRUD without restarting FreeSWITCH |
+| `presence_id` set in dialplan (not directory) | Same channel can be parked in *any* slot; we can't hard-code the presence identity at register time. Setting `presence_id` right before `valet_park` publishes the correct SUBSCRIBE dialog |
+| Park the remote leg, not the user's leg | Parking the far side preserves the operator's own channel for continued UI interaction (transfer announcement, hold music, etc.) |
+| `action_fs_park_by_uuid(uuid)` on `connect.call` | The Verto widget only knows the Verto `callId` (FS UUID). The server maps UUID → channel → call → slot, so the frontend stays free of Odoo record IDs |
+| Webhook GET with query params | Easier to emit from dialplan `curl`/`api_hangup_hook` than crafting a POST body. Idempotent on replay |
+| Served dialplan (not static) | The valet extension is rendered from a Jinja2 template (ADR-007) with the slot's `exten` and webhook URL. Changing slots doesn't require a FreeSWITCH restart — `mod_xml_curl` re-fetches on next dial |
+| Bus channel `connect_actions` reuse | Already consumed by `connect_twilio` for `connect_notify` / `reload_view`; adding another event type is the least-surprising path |
+
+## Implementation Details
+
+### Dialplan (rendered from template `dialplan_valet_parking`)
+```xml
+<extension name="connect_valet_parking_{{ slot }}">
+  <condition field="destination_number" expression="^{{ slot }}$">
+    <action application="answer"/>
+    <action application="set" data="presence_id={{ slot }}@${domain_name}"/>
+    <action application="set" data="api_hangup_hook=bgapi curl {{ webhook_url }}/freeswitch/webhook/parking?event=released&amp;slot={{ slot }}"/>
+    <action application="curl" data="{{ webhook_url }}/freeswitch/webhook/parking?event=entered&amp;slot={{ slot }}&amp;uuid=${uuid}&amp;caller_number=${caller_id_number}&amp;caller_name=${caller_id_name} background"/>
+    <action application="valet_park" data="{{ lot_name }} {{ slot }}"/>
+  </condition>
+</extension>
+```
+
+### Sofia profile presence params (appended to `fs_template_config_sofia`)
+```xml
+<param name="manage-presence" value="true"/>
+<param name="send-presence-on-register" value="first-register"/>
+<param name="presence-hosts" value="${fs_domain},${local_ip_v4}"/>
+```
+
+### XML controller routing (`freeswitch_xml.py::_route_internal`)
+Before the regular extension lookup, match the destination against an active parking slot. If found, render the valet dialplan extension and return.
+
+### Webhook idempotency
+- `entered` with the same UUID twice → no-op (early return, fields not overwritten).
+- `entered` for an unknown slot → logged warning, 200 response (FreeSWITCH has no way to recover from webhook errors; don't break the park).
+- `released` on an already-empty slot → 200 no-op.
+
+### Bus protocol
+Channel: `connect_actions`
+Event type: `parking_state_changed`
+Payload: `{id, exten, is_occupied}`
+
+Frontend (`phone_service.js`) subscribes via `bus_service.subscribe("parking_state_changed", …)` and re-emits the event on the local Verto EventBus as `parkingStateChanged`; the `ParkingPanel` component refreshes on that event.
+
+## Files Changed
+
+### Server
+- `connect_freeswitch/models/fs_parking_slot.py` — new model + webhook handlers
+- `connect_freeswitch/models/call.py` — `fs_parked_slot`, `action_fs_park`, `action_fs_park_by_uuid`
+- `connect_freeswitch/controllers/freeswitch_parking.py` — `/freeswitch/webhook/parking` endpoint
+- `connect_freeswitch/controllers/freeswitch_xml.py` — route parking extens to the new dialplan template
+- `connect_freeswitch/data/fs_templates.xml` — new `dialplan_valet_parking` template; presence params in sofia template
+- `connect_freeswitch/data/parking_slots.xml` — six default slots (701–706)
+- `connect_freeswitch/views/fs_parking_slot_views.xml` — admin CRUD
+- `connect_freeswitch/views/call_views.xml` — Park button + parked-slot badge
+- `connect_freeswitch/security/access_rules.xml` — ACLs
+- `connect_freeswitch/deploy/freeswitch/conf/autoload_configs/modules.conf.xml` — load `mod_valet_parking`
+- `connect_freeswitch/__manifest__.py` — version bump `19.0.1.7.0`
+
+### Frontend
+- `connect_freeswitch/static/src/js/parking_panel.js` — `ParkingPanel` OWL component
+- `connect_freeswitch/static/src/xml/parking_panel.xml` — template
+- `connect_freeswitch/static/src/js/phone_panel.js` — tabs state (Dialer/Parking)
+- `connect_freeswitch/static/src/xml/phone_systray.xml` — tab bar
+- `connect_freeswitch/static/src/js/phone_service.js` — bus subscription
+- `connect_freeswitch/static/src/css/phone_systray.css` — tab + slot styling
+
+### Tests
+- `tests_suite/connect_freeswitch/tests/test_parking.py` — park, unpark, webhook (incl. HTTP case)
+
+### Docs
+- `docs/user/parking.md`, `docs/admin/parking.md`, `docs/mkdocs.yml`


### PR DESCRIPTION
## Summary
- Adds call parking via `mod_valet_parking` with a new `connect.freeswitch.parking.slot` model, a Park/Unpark button on `connect.call`, and a Parking tab in the Verto phone widget.
- Publishes SIP presence (PIDF) and dialog-info NOTIFY on park/unpark so BLF lamps on SIP phones reflect slot state; webhook controller keeps Odoo state in sync with FreeSWITCH.
- Bundles `mod_valet_parking` into the FreeSWITCH image, ships default slots (701–706), adds admin/user docs, and records ADR 012.

## Test plan
- [ ] Park an active call via the Verto Parking tab; BLF lamp on a subscribed SIP phone lights red.
- [ ] Pick up by dialing the slot from the SIP phone or clicking Unpark in Verto; lamp returns to green.
- [ ] Park from the `connect.call` form, then reset a stale slot via admin action.