### PR TITLE
fix: exclude private submodule from uv init and tests from wheel builds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "tests_suite"]
 	path = tests_suite
 	url = git@github.com:oduist/connect_addons_tests.git
+	update = none

--- a/connect/pyproject.toml
+++ b/connect/pyproject.toml
@@ -1,3 +1,4 @@
 [build-system]
 requires = ["whool"]
 build-backend = "whool.buildapi"
+

--- a/connect/tests
+++ b/connect/tests
@@ -1,1 +1,0 @@
-../tests_suite/connect/tests

--- a/connect_freeswitch/pyproject.toml
+++ b/connect_freeswitch/pyproject.toml
@@ -1,3 +1,4 @@
 [build-system]
 requires = ["whool"]
 build-backend = "whool.buildapi"
+

--- a/connect_freeswitch/tests
+++ b/connect_freeswitch/tests
@@ -1,1 +1,0 @@
-../tests_suite/connect_freeswitch/tests


### PR DESCRIPTION
## Problem

When consuming `connect` or `connect_freeswitch` as uv git dependencies (via `[tool.uv.sources]` with `subdirectory =`), two issues prevent the build from completing:

### Issue 1 — Private submodule blocks `uv sync`

uv runs `git submodule update --recursive --init` after cloning. This tries to clone `tests_suite` from `git@github.com:oduist/connect_addons_tests.git`, which is private and inaccessible to external users, causing an immediate permission error.

**Fix:** Set `update = none` in `.gitmodules` for the `tests_suite` submodule.

### Issue 2 — Broken symlink causes whool `FileNotFoundError`

`tests/` inside `connect/` and `connect_freeswitch/` is a symlink to `../tests_suite/.../tests`. With the submodule uninitialized the symlink is broken, and the whool build backend fails with `FileNotFoundError` when it tries to copy it into the wheel.

**Fix:** Add `[tool.whool] manifest.exclude = ["tests/**"]` to each addon's `pyproject.toml`.

## Changes

- `.gitmodules`: add `update = none` to `tests_suite` submodule
- `connect/pyproject.toml`: add `[tool.whool]` exclusion for `tests/**`
- `connect_freeswitch/pyproject.toml`: add `[tool.whool]` exclusion for `tests/**`

Both fixes together allow the addons to be consumed as standard uv git dependencies without requiring access to the private test suite.