### PR TITLE
fix(freeswitch): single-codebase USER_GROUPS_FIELD + cross-branch CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,26 @@ Use oduflow to manage module development and deployment.
 
 Code includes `release.version_info[0]` checks to support Odoo 17.0, 18.0, and 19.0 differences (Html field sanitize, check_access methods, Constraint class, user_ids attribute).
 
+### Cross-branch versioning rules
+
+The same product ships on each Odoo branch; only the leading series prefix
+differs. Concretely:
+
+- **Manifest versions are aligned across branches.** If a module is at
+  `19.0.1.8.13` on the `19.0` branch, the same module on the `18.0`
+  branch must be at `18.0.1.8.13` once the corresponding change is
+  ported. The tail (`1.8.13`) is the product version; the head (`19.0`,
+  `18.0`) only marks the target Odoo series.
+- **Each branch keeps only its own series migrations.** The `18.0` branch
+  carries `migrations/18.0.x.x.x/`, the `19.0` branch carries
+  `migrations/19.0.x.x.x/`. Do not leave migration folders for other
+  Odoo series sitting in a branch — they never run there and only
+  confuse readers.
+- **Backports use the same Python helpers.** When the change involves a
+  Python migration script, both branches should call the same module
+  function (e.g. `setup_firewall(env)`), with the per-series migration
+  folder acting purely as the entry point Odoo can match.
+
 ## Conventions
 
 - Models follow `connect.<name>` naming (e.g., `connect.call`, `connect.recording`)

--- a/connect_freeswitch/__init__.py
+++ b/connect_freeswitch/__init__.py
@@ -4,9 +4,15 @@ from . import models
 import logging
 import secrets
 
-from odoo import fields
+from odoo import fields, release
 
 _logger = logging.getLogger(__name__)
+
+
+# In Odoo 19 the M2M between res.users and res.groups was renamed from
+# groups_id to group_ids. Keep one source of truth here so callers do
+# not have to repeat the check.
+USER_GROUPS_FIELD = 'group_ids' if release.version_info[0] >= 19 else 'groups_id'
 
 
 def setup_firewall(env):
@@ -24,15 +30,16 @@ def setup_firewall(env):
         raise_if_not_found=False,
     )
     if user:
+        current = user[USER_GROUPS_FIELD]
         ops = []
-        if group_user and group_user in user.group_ids:
+        if group_user and group_user in current:
             ops.append((3, group_user.id))
-        if group_portal and group_portal not in user.group_ids:
+        if group_portal and group_portal not in current:
             ops.append((4, group_portal.id))
-        if group_agent and group_agent not in user.group_ids:
+        if group_agent and group_agent not in current:
             ops.append((4, group_agent.id))
         if ops:
-            user.sudo().write({'group_ids': ops})
+            user.sudo().write({USER_GROUPS_FIELD: ops})
 
     settings = env['connect.settings'].sudo()
     if not settings.get_param('firewall_service_token'):

--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.8.13',
+    'version': '19.0.1.8.14',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',


### PR DESCRIPTION
## Summary
Forward-port from the 18.0 backport (PR #60) of the firewall feature so both branches share an identical Python codebase per project policy.

- `connect_freeswitch/__init__.py`: replace the hard-coded `'group_ids'` with a module-level `USER_GROUPS_FIELD = 'group_ids' if release.version_info[0] >= 19 else 'groups_id'`. Behaviour on 19.0 is unchanged (the selector evaluates to `'group_ids'`), but the same file now works verbatim on the 18.0 branch.
- `CLAUDE.md`: copy the **Cross-branch versioning rules** section that was added during the 18.0 backport so the guidance is the same in both branches.
- `connect_freeswitch/__manifest__.py`: bump to `19.0.1.8.14` for the code change.

## Test plan
- [x] Code review: change is a mechanical refactor; on 19.0 the selector evaluates to the previous literal.
- [x] Syntax compiles; `setup_firewall(env)` already verified end-to-end on 19.0 env `fw` before this PR.
- [ ] Optional: rerun the firewall integration in `fw` after merge to confirm no regression (no behaviour change expected).