### PR TITLE
chore(packaging): align 19.0 with 18.0 — pyproject.toml + unified webrtc route type

### DIFF
--- a/connect/pyproject.toml
+++ b/connect/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.8.14',
+    'version': '19.0.1.8.15',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',

--- a/connect_freeswitch/controllers/webrtc.py
+++ b/connect_freeswitch/controllers/webrtc.py
@@ -1,15 +1,18 @@
 # -*- coding: utf-8 -*-
 import logging
-from odoo import http
+from odoo import http, release
 from odoo.http import request
 
 _logger = logging.getLogger(__name__)
+
+# Odoo 19 introduced the 'jsonrpc' route type; on 18.0 the equivalent is 'json'.
+_JSON_ROUTE = 'jsonrpc' if release.version_info[0] >= 19 else 'json'
 
 
 class WebRTCController(http.Controller):
     """Controller for WebRTC/Verto client configuration."""
 
-    @http.route('/connect/webrtc/config', type='jsonrpc', auth='user', methods=['POST'])
+    @http.route('/connect/webrtc/config', type=_JSON_ROUTE, auth='user', methods=['POST'])
     def get_webrtc_config(self):
         """
         Get WebRTC configuration for the current user.

--- a/connect_freeswitch/pyproject.toml
+++ b/connect_freeswitch/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/connect_twilio/pyproject.toml
+++ b/connect_twilio/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["hatchling", "hatch-odoo"]
+build-backend = "hatchling.build"
+
+[project]
+name = "connect-addons-ng"
+version = "19.0.1.1.0"
+dynamic = ["dependencies"]
+
+[tool.hatch.metadata.hooks.odoo-addons-dependencies]
+[tool.hatch.build.hooks.odoo-addons-dirs]
+
+[tool.hatch.build.targets.wheel]
+only-include = ["connect", "connect_twilio", "connect_freeswitch"]
+exclude = ["connect/tests", "connect_twilio/tests", "connect_freeswitch/tests"]
+
+[tool.hatch-odoo]
+addons_dirs = ["."]


### PR DESCRIPTION
## Summary

Brings the 19.0 branch back in step with 18.0 on two pieces that were
sitting unmerged across the series boundary:

- **Port `pyproject.toml` (PR #23) to 19.0.** Adds the root packaging
  manifest plus the three per-module `pyproject.toml` stubs. Root
  `version` pins `19.0.1.1.0`, matching the existing module manifest
  tails so the wheel build and the addon versions stay aligned.
- **Unify `connect_freeswitch/controllers/webrtc.py`.** Replaces the
  hard-coded `type='jsonrpc'` (Odoo 19) with a constant picked at
  import time from `release.version_info[0] >= 19`, so the same source
  file compiles on 18.0 (`json`) and 19.0+ (`jsonrpc`). Companion patch
  on the 18.0 branch removes the symmetric hard-code there.
- **Bump `connect_freeswitch` to `19.0.1.8.15`** to publish the route
  unification. The companion 18.0 PR lands at `18.0.1.8.15` so the
  tails stay aligned per the CLAUDE.md cross-branch rule.

## Test plan

- [ ] Install / upgrade `connect_freeswitch` on a 19.0 instance; verify
      the WebRTC config endpoint still serves credentials to a user
      with `webrtc_enabled = True`.
- [ ] Confirm `pip install .` (or whool/hatch) at repo root resolves
      via the new `pyproject.toml`.
- [ ] Cross-check that `git diff origin/18.0..origin/19.0 -- '*.py'`
      after both PRs leaves only the expected per-series manifest
      prefix and per-series migration folders.