### PR TITLE
fix(freeswitch): report misconfigured gateway as "Not loaded" instead of "Parse error"

### DIFF
--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.8.15',
+    'version': '19.0.1.8.16',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',

--- a/connect_freeswitch/models/settings.py
+++ b/connect_freeswitch/models/settings.py
@@ -348,17 +348,24 @@ class Settings(models.Model):
             gw_response = self.freeswitch_api(
                 'sofia', 'xmlstatus gateway {}'.format(gw.name))
             gw_status = 'Unknown'
-            if gw_response and not gw_response.startswith('-ERR'):
+            if not gw_response:
+                gw_status = 'Unreachable'
+            elif gw_response.startswith('-ERR'):
+                gw_status = 'Not loaded'
+            elif gw_response.lstrip().startswith('<'):
                 try:
                     gw_root = ET.fromstring(gw_response)
                     raw = gw_root.findtext('status', 'Unknown').strip()
                     gw_status = status_map.get(raw, raw)
                 except ET.ParseError:
                     gw_status = 'Parse error'
-            elif gw_response and gw_response.startswith('-ERR'):
-                gw_status = 'Not found in sofia'
             else:
-                gw_status = 'Unreachable'
+                # Sofia returns plain text like "Invalid Gateway!" when the
+                # gateway failed to load (e.g. missing password while
+                # register=true). Surface the first line verbatim so the
+                # admin can act on the actual reason.
+                gw_status = 'Not loaded ({})'.format(
+                    gw_response.splitlines()[0].strip())
             gateway_lines.append('{}: {}'.format(gw.name, gw_status))
 
         self.write({


### PR DESCRIPTION
## Summary
- When Sofia fails to load a gateway (e.g. `register=true` with empty `password`), `sofia xmlstatus gateway <name>` returns the plain string `Invalid Gateway!`. The previous status detector tried to parse that as XML and surfaced an opaque `Parse error` in the General Settings panel.
- Now the response is classified by shape:
  - empty → `Unreachable`
  - `-ERR …` → `Not loaded`
  - starts with `<` → parse XML (genuine `Parse error` reserved for malformed XML)
  - anything else → `Not loaded (<first line of reply>)`
- This makes a missing-password / typo'd gateway diagnosable straight from the UI instead of looking like an Odoo bug.

## Test plan
- [ ] Configure a gateway with `register = true` and empty `password`.
- [ ] Click **Check Status** in General Settings → FreeSWITCH → confirm Gateway Statuses now shows e.g. `test-gw: Not loaded (Invalid Gateway!)` instead of `Parse error`.
- [ ] Configure a healthy gateway → confirm it still shows the registration status (`UP (Registered)` etc).