### PR TITLE
fix(packaging): make per-addon wheels buildable without tests_suite

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "tests_suite"]
 	path = tests_suite
 	url = git@github.com:oduist/connect_addons_tests.git
+	update = none

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,32 +124,44 @@ If a code change adds, removes, or modifies a feature, the corresponding documen
 
 ## Architecture
 
-Tests live in a **private git submodule** (`tests_suite/`), separate from the business logic:
+Tests live in a **private git submodule** (`tests_suite/`), separate from the business logic. Each addon ships a tracked `tests/__init__.py` that conditionally pulls `test_*.py` from the submodule at import time:
 
 ```
 connect_addons_ng/              ← Main repo (public)
 ├── connect/
-│   └── tests → ../tests_suite/connect/tests          (symlink)
+│   └── tests/__init__.py       ← conditional loader (tracked)
 ├── connect_twilio/
-│   └── tests → ../tests_suite/connect_twilio/tests    (symlink)
+│   └── tests/__init__.py       ← conditional loader (tracked)
 ├── connect_freeswitch/
-│   └── tests → ../tests_suite/connect_freeswitch/tests (symlink)
+│   └── tests/__init__.py       ← conditional loader (tracked)
 └── tests_suite/                ← Private submodule (oduist/connect_addons_tests)
-    ├── connect/tests/
-    ├── connect_twilio/tests/
-    └── connect_freeswitch/tests/
+    ├── connect/tests/test_*.py
+    ├── connect_twilio/tests/test_*.py
+    └── connect_freeswitch/tests/test_*.py
 ```
+
+The loader checks `os.path.isdir("../../tests_suite/<addon>/tests")`. When present, it dynamically loads each `test_*.py` via `importlib.util.spec_from_file_location` and registers it as a submodule of `<addon>.tests`. When absent, the loader is a no-op — the addon installs cleanly with no tests.
 
 ## Operating Modes
 
-**Unprotected Mode** — The `tests_suite` submodule is not initialized. Symlinks are broken, `tests/` directories are empty. Code can be modified but not verified. A missing `tests/` folder is NOT an error — it means the test suite license is not active.
+**Unprotected Mode** — The `tests_suite` submodule is not initialized. The loader sees no `tests_suite/` directory and exposes an empty `tests` package. Code can be modified but not verified. A missing `tests_suite/` is NOT an error — it means the test suite license is not active.
 
-**Safe Mode** — The `tests_suite` submodule is initialized. Symlinks resolve. Use tests as the primary success criterion for every task.
+**Safe Mode** — The `tests_suite` submodule is initialized. The loader registers all `test_*.py` files. Use tests as the primary success criterion for every task.
+
+## Submodule init policy
+
+`.gitmodules` carries `update = none` for `tests_suite`. This makes the default `git submodule update --init` (and `uv sync`'s `git submodule update --init --recursive`) silently skip the private submodule, so external users without access can clone the repo and build addons as uv dependencies.
+
+Internal developers who need tests initialize the submodule explicitly:
+
+```bash
+git -c submodule.tests_suite.update=checkout submodule update --init tests_suite
+```
 
 ## Agent Behavior
 
 - **Always check** if `tests_suite/` is populated before attempting to run tests.
-- **Never treat** a missing or broken `tests/` symlink as a bug.
+- **Never treat** a missing `tests_suite/` as a bug.
 - **In Safe Mode**: run tests after every code change. Tests are the gatekeeper.
 - **In Unprotected Mode**: rely on manual verification and code review.
 - **When writing new tests**: place them in `tests_suite/<module>/tests/`, not directly in the module.
@@ -159,20 +171,41 @@ connect_addons_ng/              ← Main repo (public)
 When creating a new module (e.g., `connect_crm`):
 
 1. Create the test scaffold in the submodule: `tests_suite/connect_crm/tests/__init__.py`
-2. Create a symlink from inside the module: `cd connect_crm && ln -s ../tests_suite/connect_crm/tests tests`
-3. Commit the symlink to the main repo and the scaffold to `tests_suite`
+2. Create `connect_crm/tests/__init__.py` in the main repo — copy the loader from `connect/tests/__init__.py` and change the `_SUITE` path to `connect_crm`.
+3. Commit both files.
+
+## Note on relative imports in tests
+
+The loader registers each `test_*.py` individually via `importlib.util.spec_from_file_location`. Modules are formally part of `<addon>.tests` but physically live in `tests_suite/`. As a consequence, **relative imports between test modules will not work** (e.g. `from . import helpers` inside `test_foo.py`).
+
+Today this is not a problem — `tests_suite` only contains `test_firewall.py` with no helpers. If helper modules become necessary:
+
+- **Preferred:** use absolute imports (`from tests_suite.<addon>.tests import helpers`).
+- **Alternative:** extend the loader to do a two-pass load — first non-`test_*` modules (helpers), then `test_*` ones.
 
 ## Running Tests
 
 ```bash
-# Setup symlinks (one-time, after cloning)
-git submodule update --init
+# Setup tests (one-time, after cloning) — requires tests_suite access
+git -c submodule.tests_suite.update=checkout submodule update --init tests_suite
 
 # Run tests via oduflow
 oduflow run_odoo_tests connect
 oduflow run_odoo_tests connect_twilio
 oduflow run_odoo_tests connect_freeswitch
 ```
+
+## Installing as a uv dependency (external consumers)
+
+External users can install individual addons without access to `tests_suite`:
+
+```bash
+uv pip install "odoo-addon-connect @ git+https://github.com/oduist/connect_addons_ng.git@18.0#subdirectory=connect"
+uv pip install "odoo-addon-connect-twilio @ git+https://github.com/oduist/connect_addons_ng.git@18.0#subdirectory=connect_twilio"
+uv pip install "odoo-addon-connect-freeswitch @ git+https://github.com/oduist/connect_addons_ng.git@18.0#subdirectory=connect_freeswitch"
+```
+
+Replace `@18.0` with `@19.0` for the Odoo 19 series. Tests are not available in this mode.
 
 ## Self-driven verification of changes
 

--- a/connect/tests
+++ b/connect/tests
@@ -1,1 +1,0 @@
-../tests_suite/connect/tests

--- a/connect/tests/__init__.py
+++ b/connect/tests/__init__.py
@@ -1,0 +1,39 @@
+"""Conditional test loader.
+
+When the private tests_suite submodule is initialised, dynamically loads
+test_*.py modules from tests_suite/connect/tests/ and exposes them as
+submodules so Odoo's test discovery (inspect.getmembers + ismodule)
+picks them up.
+
+When tests_suite is absent (external uv consumers, fresh clones without
+the private submodule), this file is a no-op and the addon installs
+cleanly with no tests.
+
+MUST NEVER raise: odoo.tests.loader._get_tests_modules does not wrap
+the import call, so any exception here aborts test collection for the
+whole addon.
+"""
+import importlib.util
+import os
+import sys
+
+_SUITE = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "..", "..",
+                 "tests_suite", "connect", "tests")
+)
+
+if os.path.isdir(_SUITE):
+    for _fn in sorted(os.listdir(_SUITE)):
+        if not (_fn.startswith("test_") and _fn.endswith(".py")):
+            continue
+        _name = _fn[:-3]
+        _full = f"{__name__}.{_name}"
+        try:
+            _spec = importlib.util.spec_from_file_location(
+                _full, os.path.join(_SUITE, _fn))
+            _mod = importlib.util.module_from_spec(_spec)
+            sys.modules[_full] = _mod
+            _spec.loader.exec_module(_mod)
+            globals()[_name] = _mod
+        except Exception:
+            pass

--- a/connect_freeswitch/tests
+++ b/connect_freeswitch/tests
@@ -1,1 +1,0 @@
-../tests_suite/connect_freeswitch/tests

--- a/connect_freeswitch/tests/__init__.py
+++ b/connect_freeswitch/tests/__init__.py
@@ -1,0 +1,39 @@
+"""Conditional test loader.
+
+When the private tests_suite submodule is initialised, dynamically loads
+test_*.py modules from tests_suite/connect_freeswitch/tests/ and exposes
+them as submodules so Odoo's test discovery (inspect.getmembers + ismodule)
+picks them up.
+
+When tests_suite is absent (external uv consumers, fresh clones without
+the private submodule), this file is a no-op and the addon installs
+cleanly with no tests.
+
+MUST NEVER raise: odoo.tests.loader._get_tests_modules does not wrap
+the import call, so any exception here aborts test collection for the
+whole addon.
+"""
+import importlib.util
+import os
+import sys
+
+_SUITE = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "..", "..",
+                 "tests_suite", "connect_freeswitch", "tests")
+)
+
+if os.path.isdir(_SUITE):
+    for _fn in sorted(os.listdir(_SUITE)):
+        if not (_fn.startswith("test_") and _fn.endswith(".py")):
+            continue
+        _name = _fn[:-3]
+        _full = f"{__name__}.{_name}"
+        try:
+            _spec = importlib.util.spec_from_file_location(
+                _full, os.path.join(_SUITE, _fn))
+            _mod = importlib.util.module_from_spec(_spec)
+            sys.modules[_full] = _mod
+            _spec.loader.exec_module(_mod)
+            globals()[_name] = _mod
+        except Exception:
+            pass

--- a/connect_twilio/tests
+++ b/connect_twilio/tests
@@ -1,1 +1,0 @@
-../tests_suite/connect_twilio/tests

--- a/connect_twilio/tests/__init__.py
+++ b/connect_twilio/tests/__init__.py
@@ -1,0 +1,39 @@
+"""Conditional test loader.
+
+When the private tests_suite submodule is initialised, dynamically loads
+test_*.py modules from tests_suite/connect_twilio/tests/ and exposes them
+as submodules so Odoo's test discovery (inspect.getmembers + ismodule)
+picks them up.
+
+When tests_suite is absent (external uv consumers, fresh clones without
+the private submodule), this file is a no-op and the addon installs
+cleanly with no tests.
+
+MUST NEVER raise: odoo.tests.loader._get_tests_modules does not wrap
+the import call, so any exception here aborts test collection for the
+whole addon.
+"""
+import importlib.util
+import os
+import sys
+
+_SUITE = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "..", "..",
+                 "tests_suite", "connect_twilio", "tests")
+)
+
+if os.path.isdir(_SUITE):
+    for _fn in sorted(os.listdir(_SUITE)):
+        if not (_fn.startswith("test_") and _fn.endswith(".py")):
+            continue
+        _name = _fn[:-3]
+        _full = f"{__name__}.{_name}"
+        try:
+            _spec = importlib.util.spec_from_file_location(
+                _full, os.path.join(_SUITE, _fn))
+            _mod = importlib.util.module_from_spec(_spec)
+            sys.modules[_full] = _mod
+            _spec.loader.exec_module(_mod)
+            globals()[_name] = _mod
+        except Exception:
+            pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dynamic = ["dependencies"]
 
 [tool.hatch.build.targets.wheel]
 only-include = ["connect", "connect_twilio", "connect_freeswitch"]
-exclude = ["connect/tests", "connect_twilio/tests", "connect_freeswitch/tests"]
 
 [tool.hatch-odoo]
 addons_dirs = ["."]


### PR DESCRIPTION
## Summary

Backport of #68 to `18.0`. Identical fix, applied symmetrically.

External consumers cannot install `connect`, `connect_twilio`, or `connect_freeswitch` as `uv` git dependencies (`[tool.uv.sources]` + `subdirectory = …`) because two things break when the private `tests_suite` submodule is inaccessible:

1. `uv sync` runs `git submodule update --init --recursive`, which fails with a permission error on the private submodule.
2. whool's build backend iterates `git ls-files` and `shutil.copy()`s each entry. The tracked `<addon>/tests` symlinks pointed at `../tests_suite/<addon>/tests`; with the submodule absent the symlinks were broken → `FileNotFoundError`.

This PR fixes both. Supersedes #33 on this branch.

## Approach

- **`.gitmodules`** gets `update = none` for `tests_suite`. Default `git submodule update --init` (and uv's variant) now silently skip the private submodule. Internal devs initialise it explicitly:
  ```
  git -c submodule.tests_suite.update=checkout submodule update --init tests_suite
  ```
- **Tracked symlinks replaced by tracked `tests/__init__.py` loaders.** Each loader checks `os.path.isdir("../../tests_suite/<addon>/tests")` and dynamically loads `test_*.py` via `importlib.util.spec_from_file_location`, registering them as submodules of `<addon>.tests`. Odoo's test discovery (`inspect.getmembers + ismodule`) picks them up identically on 18.0 and 19.0. When `tests_suite` is absent, the loader is a no-op.
- **The loader must never raise** — `odoo.tests.loader._get_tests_modules` does not wrap the import call, so any exception aborts test collection for the whole addon. The loader is wrapped in `try/except Exception: pass` around each `test_*.py` load.
- **Root `pyproject.toml`**: dropped `exclude = ["<addon>/tests", ...]` so the loader files actually ship in the top-level wheel; without this hatch-odoo would strip them and break Safe Mode.
- **CLAUDE.md** rewritten: new architecture diagram, `update = none` policy, internal-dev init command, external uv install snippet (pointing at `@18.0`), and a caveat about relative imports between test modules (the dynamic loader registers them individually — `from . import helpers` will not work; use absolute imports or extend the loader with a two-pass scheme).

## Why not the approach in #33?

PR #33 deleted the symlinks but (a) did so asymmetrically (`connect_twilio` left untouched), (b) broke the Safe Mode workflow documented in CLAUDE.md, and (c) would have broken `oduflow run_odoo_tests` in dev environments because `pull_and_apply` pushes via git and untracked symlinks would not propagate.

The loader approach works across all three contexts: external uv install, local Safe Mode, and oduflow `pull_and_apply` → `run_odoo_tests` — because `tests/__init__.py` is a tracked file and travels with every push.

## Test plan

- [x] Smoke-test loader locally: with `tests_suite` present, `inspect.getmembers` on `<addon>.tests` discovers the loaded submodule and its test class. Without `tests_suite`, import returns an empty `tests` package and raises nothing.
- [ ] Build a per-addon wheel: `uv pip install "git+<this-PR>#subdirectory=connect"` in a clean clone without `tests_suite` — must succeed; `unzip -l dist/*.whl | grep tests` shows only `tests/__init__.py`.
- [ ] Build the top-level wheel: `python -m build` — must include `connect/tests/__init__.py`.
- [ ] `oduflow run_odoo_tests connect_freeswitch` in an env with `tests_suite` initialised — must run `test_firewall.py`.
- [ ] `oduflow install_odoo_modules` on a fresh env without `tests_suite` — must succeed with no load errors.