### PR TITLE
chore(freeswitch): gate res.groups users access for cross-series symmetry

### DIFF
--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.8.17',
+    'version': '19.0.1.8.18',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',

--- a/connect_freeswitch/models/firewall.py
+++ b/connect_freeswitch/models/firewall.py
@@ -5,12 +5,15 @@ from datetime import timedelta
 
 import requests
 
-from odoo import _, api, fields, models
+from odoo import _, api, fields, models, release
 from odoo.exceptions import UserError, ValidationError
 
 logger = logging.getLogger(__name__)
 
 SYNC_HTTP_TIMEOUT = 3  # seconds; reconcile cron is the safety net for misses
+
+# res.groups M2M to res.users was renamed from `users` to `user_ids` in Odoo 19.
+_GROUP_USERS_FIELD = 'user_ids' if release.version_info[0] >= 19 else 'users'
 
 
 def _validate_ip_or_cidr(value):
@@ -434,7 +437,7 @@ class FirewallAgent(models.Model):
             body += " — " + message
         admin_group = self.env.ref("connect.group_admin", raise_if_not_found=False)
         if admin_group:
-            for user in admin_group.sudo().user_ids:
+            for user in admin_group.sudo()[_GROUP_USERS_FIELD]:
                 self.env["bus.bus"]._sendone(
                     user.partner_id,
                     "simple_notification",


### PR DESCRIPTION
## Summary

Mirror of the fix that landed in #73 (18.0 branch). The M2M field between \`res.groups\` and \`res.users\` was renamed \`users → user_ids\` in Odoo 19, so the firewall code's literal \`admin_group.user_ids\` reference works here but blows up when ported to 18.0 (where the field is still \`users\`). Replace the literal in \`report_applied()\` with the same \`_GROUP_USERS_FIELD\` release-gated lookup the 18.0 branch already carries.

- No behaviour change on 19.0 — the conditional always picks \`user_ids\`.
- Both branches now share the same private helper, so future bidirectional backports of the firewall code don't need manual adaptation.
- Manifest bumped to \`19.0.1.8.18\` to keep the cross-branch version pairing (companion bump on 18.0 to \`18.0.1.8.18\` follows in #73 / a sibling commit).

## Test plan

- [ ] \`oduflow upgrade_odoo_modules connect_freeswitch\` on an Odoo 19 env succeeds and the firewall service's \`/freeswitch/firewall/api/applied\` round-trips a popup notification to admin users as before.
- [ ] (Safe Mode only) \`oduflow run_odoo_tests connect_freeswitch\`.