### PR TITLE
fix(freeswitch): IVR DTMF menu + FS Queue cleanup

### DIFF
--- a/connect/__manifest__.py
+++ b/connect/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect',
-    'version': '19.0.3.1.0',
+    'version': '19.0.3.1.1',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'Communication platform for Odoo',

--- a/connect/models/callflow.py
+++ b/connect/models/callflow.py
@@ -15,12 +15,11 @@ class CallFlow(models.Model):
     language = fields.Char(default='en-US', required=True)
     voice = fields.Char(required=True, default='Woman')
     gather_input = fields.Boolean()
+    # Core only ships DTMF. Speech-aware backends (e.g. connect_twilio) extend
+    # this selection via selection_add. FreeSWITCH stays DTMF-only.
     gather_input_type = fields.Selection(string='Input Type',
-        selection=[
-            ('dtmf speech', 'DTMF + speech'),
-            ('dtmf', 'DTMF'),
-            ('speech', 'Speech')
-        ], required=True, default='dtmf speech')
+        selection=[('dtmf', 'DTMF')],
+        required=True, default='dtmf')
     gather_timeout = fields.Integer(string='Timeout', default=5)
     gather_hints = fields.Char('Hints', default='This is a phrase I expect to hear, department name or extension number')
     prompt_message = fields.Text('Prompt Message',

--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.8.20',
+    'version': '19.0.1.8.21',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',

--- a/connect_freeswitch/controllers/freeswitch_xml.py
+++ b/connect_freeswitch/controllers/freeswitch_xml.py
@@ -323,8 +323,13 @@ class FreeSwitchXMLController(http.Controller):
         - public context: inbound DID routing via connect.number
         - default context: extension lookup, then outgoing routes, then fallback
         """
-        context = params.get('Caller-Context', params.get('Hunt-Context', 'default'))
-        destination = params.get('Caller-Destination-Number', '')
+        # Hunt-* reflects the CURRENT routing lookup (e.g. after
+        # execute_extension/transfer to a new destination), while Caller-* is
+        # the original A-leg destination. Prefer Hunt when present so that
+        # in-call hops (like the IVR's cf_call_<id>_<digit> landing extension)
+        # are routed correctly.
+        context = params.get('Hunt-Context') or params.get('Caller-Context') or 'default'
+        destination = params.get('Hunt-Destination-Number') or params.get('Caller-Destination-Number', '')
 
         debug(request.env['connect.settings'].sudo(), "Dialplan request: context=%s, destination=%s" % (context, destination))
 
@@ -388,6 +393,28 @@ class FreeSwitchXMLController(http.Controller):
                 'webhook_url': webhook_url,
             }))
             return ''.join(parts)
+
+        # IVR user-choice landing extension: bind_digit_action in dialplan_ivr
+        # transfers here when a user-typed choice is picked. Sets per-call
+        # variables and bridges to the user.
+        ivr_choice = re.match(r'^cf_call_(\d+)_(.+)$', destination)
+        if ivr_choice:
+            cf = request.env['connect.callflow'].sudo().browse(int(ivr_choice.group(1)))
+            if cf.exists():
+                choice_xml = cf._generate_ivr_choice_dialplan(ivr_choice.group(2))
+                if choice_xml:
+                    parts.append(choice_xml)
+                    return ''.join(parts)
+
+        # IVR catch-all (invalid DTMF) extension.
+        ivr_invalid = re.match(r'^cf_invalid_(\d+)$', destination)
+        if ivr_invalid:
+            cf = request.env['connect.callflow'].sudo().browse(int(ivr_invalid.group(1)))
+            if cf.exists():
+                invalid_xml = cf._generate_ivr_invalid_dialplan()
+                if invalid_xml:
+                    parts.append(invalid_xml)
+                    return ''.join(parts)
 
         # Try exact extension match
         exten = Exten.search([('number', '=', destination)], limit=1)

--- a/connect_freeswitch/data/fs_templates.xml
+++ b/connect_freeswitch/data/fs_templates.xml
@@ -188,78 +188,125 @@ Variables:
         <field name="key">dialplan_ivr</field>
         <field name="name">Dialplan - IVR</field>
         <field name="section">dialplan</field>
-        <field name="description">Interactive Voice Response using speak (Piper TTS) + read for digit collection, with inline choice conditions.
+        <field name="description">Interactive Voice Response. Uses bind_digit_action so a DTMF press during the
+Piper TTS prompt instantly interrupts speak and triggers the matching choice.
+User choices route through a dedicated extension (cf_call_&lt;id&gt;_&lt;digit&gt;) that
+sets per-call variables and bridges to the user; other destinations transfer
+directly to the chosen target.
 
 Variables:
   callflow_id     - connect.callflow record ID
   number          - Extension number (escaped for regex)
   lang            - Piper TTS language code (e.g. 'en')
   prompt          - TTS prompt text (plain text with spaces)
-  min_digits      - Minimum digits to collect
-  max_digits      - Maximum digits to collect
-  timeout         - Digit collection timeout in milliseconds
-  var_name        - Channel variable name for collected digits
+  timeout         - Post-prompt wait window in milliseconds (gather_timeout * 1000)
   choices         - List of dicts, each with:
-    digits_escaped  - Choice digits (escaped for regex)
+    digits          - Choice digits (raw, used as bind_digit_action pattern)
     dst_type        - Destination type: 'user' or 'other'
     user_id         - connect.user ID (if dst_type == 'user')
     user_number     - User extension number (if dst_type == 'user')
     transfer_target - Transfer destination (if dst_type == 'other')
-  fs_domain       - FreeSWITCH SIP domain
-  fifo_number     - FS Queue extension number for IVR default branch (optional)</field>
+  fs_domain       - FreeSWITCH SIP domain (unused in this template; kept for symmetry)
+  ring_bridge     - Comma-separated bridge string for ring_users fallback after timeout (optional)
+  fifo_number     - FS Queue extension number for IVR default branch (optional)
+  invalid_regex   - Pre-built `~^[unused-digits]$` pattern for the catch-all bind (optional)
+  dmachine_timeout - bind_digit_digit_timeout in ms (100 for single-digit menus, 1500 for multi-digit)</field>
         <field name="content"><![CDATA[<extension name="callflow_{{ callflow_id }}">
   <condition field="destination_number" expression="^{{ number }}$" break="on-false">
     <action application="answer"/>
     <action application="sleep" data="500"/>
-    <action application="speak" data="piper|{{ lang }}|{{ prompt }}"/>
-    <action application="read" data="{{ min_digits }} {{ max_digits }} silence_stream://250 {{ var_name }} {{ timeout }} #"/>
-  </condition>
-  {% for choice in choices %}
-  <condition field="${ {{- var_name -}} }" expression="^{{ choice.digits_escaped }}$" break="on-true">
+    <action application="set" data="bind_digit_digit_timeout={{ dmachine_timeout }}"/>
+    {% for choice in choices %}
     {% if choice.dst_type == 'user' %}
-    <action application="set" data="odoo_called_user_id={{ choice.user_id }}"/>
-    <action application="export" data="nolocal:odoo_parent_uuid=${uuid}"/>
+    <action application="bind_digit_action" data="cf_{{ callflow_id }},{{ choice.digits }},exec:execute_extension,cf_call_{{ callflow_id }}_{{ choice.digits }} XML default"/>
+    {% else %}
+    <action application="bind_digit_action" data="cf_{{ callflow_id }},{{ choice.digits }},exec:transfer,{{ choice.transfer_target }} XML default"/>
+    {% endif %}
+    {% endfor %}
+    {% if invalid_regex %}
+    <action application="bind_digit_action" data="cf_{{ callflow_id }},{{ invalid_regex }},exec:execute_extension,cf_invalid_{{ callflow_id }} XML default"/>
+    {% endif %}
+    <action application="digit_action_set_realm" data="cf_{{ callflow_id }}"/>
+    <action application="speak" data="piper|{{ lang }}|{{ prompt }}"/>
+    <action application="sleep" data="{{ timeout }}"/>
+    <action application="clear_digit_action" data="cf_{{ callflow_id }}"/>
+    {% if ring_bridge %}
     <action application="set" data="call_timeout=30"/>
     <action application="set" data="hangup_after_bridge=true"/>
     <action application="set" data="continue_on_fail=true"/>
-    <action application="bridge" data="user/{{ choice.user_number }}@{{ fs_domain }}"/>
-    {% else %}
-    <action application="transfer" data="{{ choice.transfer_target }} XML default"/>
+    <action application="bridge" data="{{ ring_bridge }}"/>
+    {% endif %}
+    {% if fifo_number %}
+    <action application="transfer" data="{{ fifo_number }} XML default"/>
     {% endif %}
   </condition>
-  {% endfor %}
-  {% if fifo_number %}
-  <condition field="${ {{- var_name -}} }" expression=".*" break="on-true">
-    <action application="transfer" data="{{ fifo_number }} XML default"/>
-  </condition>
-  {% endif %}
 </extension>]]></field>
         <field name="default_content"><![CDATA[<extension name="callflow_{{ callflow_id }}">
   <condition field="destination_number" expression="^{{ number }}$" break="on-false">
     <action application="answer"/>
     <action application="sleep" data="500"/>
-    <action application="speak" data="piper|{{ lang }}|{{ prompt }}"/>
-    <action application="read" data="{{ min_digits }} {{ max_digits }} silence_stream://250 {{ var_name }} {{ timeout }} #"/>
-  </condition>
-  {% for choice in choices %}
-  <condition field="${ {{- var_name -}} }" expression="^{{ choice.digits_escaped }}$" break="on-true">
+    <action application="set" data="bind_digit_digit_timeout={{ dmachine_timeout }}"/>
+    {% for choice in choices %}
     {% if choice.dst_type == 'user' %}
-    <action application="set" data="odoo_called_user_id={{ choice.user_id }}"/>
+    <action application="bind_digit_action" data="cf_{{ callflow_id }},{{ choice.digits }},exec:execute_extension,cf_call_{{ callflow_id }}_{{ choice.digits }} XML default"/>
+    {% else %}
+    <action application="bind_digit_action" data="cf_{{ callflow_id }},{{ choice.digits }},exec:transfer,{{ choice.transfer_target }} XML default"/>
+    {% endif %}
+    {% endfor %}
+    {% if invalid_regex %}
+    <action application="bind_digit_action" data="cf_{{ callflow_id }},{{ invalid_regex }},exec:execute_extension,cf_invalid_{{ callflow_id }} XML default"/>
+    {% endif %}
+    <action application="digit_action_set_realm" data="cf_{{ callflow_id }}"/>
+    <action application="speak" data="piper|{{ lang }}|{{ prompt }}"/>
+    <action application="sleep" data="{{ timeout }}"/>
+    <action application="clear_digit_action" data="cf_{{ callflow_id }}"/>
+    {% if ring_bridge %}
+    <action application="set" data="call_timeout=30"/>
+    <action application="set" data="hangup_after_bridge=true"/>
+    <action application="set" data="continue_on_fail=true"/>
+    <action application="bridge" data="{{ ring_bridge }}"/>
+    {% endif %}
+    {% if fifo_number %}
+    <action application="transfer" data="{{ fifo_number }} XML default"/>
+    {% endif %}
+  </condition>
+</extension>]]></field>
+    </record>
+
+    <record id="fs_template_dialplan_ivr_choice" model="connect.freeswitch.template">
+        <field name="key">dialplan_ivr_choice</field>
+        <field name="name">Dialplan - IVR User Choice</field>
+        <field name="section">dialplan</field>
+        <field name="description">Landing extension used by dialplan_ivr when a user-typed IVR choice
+fires. Sets per-call variables (so Odoo's event handler attributes the
+call to the right user) and bridges to the user's SIP endpoint.
+
+Variables:
+  callflow_id     - connect.callflow record ID
+  digits          - The chosen DTMF sequence (raw)
+  digits_escaped  - The chosen DTMF sequence (regex-escaped)
+  user_id         - connect.user ID
+  user_number     - User extension number
+  fs_domain       - FreeSWITCH SIP domain</field>
+        <field name="content"><![CDATA[<extension name="cf_call_{{ callflow_id }}_{{ digits }}">
+  <condition field="destination_number" expression="^cf_call_{{ callflow_id }}_{{ digits_escaped }}$" break="on-false">
+    <action application="set" data="odoo_called_user_id={{ user_id }}"/>
     <action application="export" data="nolocal:odoo_parent_uuid=${uuid}"/>
     <action application="set" data="call_timeout=30"/>
     <action application="set" data="hangup_after_bridge=true"/>
     <action application="set" data="continue_on_fail=true"/>
-    <action application="bridge" data="user/{{ choice.user_number }}@{{ fs_domain }}"/>
-    {% else %}
-    <action application="transfer" data="{{ choice.transfer_target }} XML default"/>
-    {% endif %}
+    <action application="bridge" data="user/{{ user_number }}@{{ fs_domain }}"/>
   </condition>
-  {% endfor %}
-  {% if fifo_number %}
-  <condition field="${ {{- var_name -}} }" expression=".*" break="on-true">
-    <action application="transfer" data="{{ fifo_number }} XML default"/>
+</extension>]]></field>
+        <field name="default_content"><![CDATA[<extension name="cf_call_{{ callflow_id }}_{{ digits }}">
+  <condition field="destination_number" expression="^cf_call_{{ callflow_id }}_{{ digits_escaped }}$" break="on-false">
+    <action application="set" data="odoo_called_user_id={{ user_id }}"/>
+    <action application="export" data="nolocal:odoo_parent_uuid=${uuid}"/>
+    <action application="set" data="call_timeout=30"/>
+    <action application="set" data="hangup_after_bridge=true"/>
+    <action application="set" data="continue_on_fail=true"/>
+    <action application="bridge" data="user/{{ user_number }}@{{ fs_domain }}"/>
   </condition>
-  {% endif %}
 </extension>]]></field>
     </record>
 
@@ -415,9 +462,8 @@ Variables:
   fifo_name          - FIFO queue name (e.g. fs_fifo_42)
   number             - Extension number (escaped for regex)
   exten_id           - connect.exten record ID (may be empty)
-  max_wait           - Seconds to wait in the queue
-  moh                - Music-on-Hold source
-  announce_position  - Boolean, announce caller position
+  max_wait           - Seconds to wait in the queue (enforced via fifo_orbit_exten)
+  moh                - Music-on-Hold source (fed as fifo's `music_file` arg)
   record_calls       - Boolean, record the call leg
   recording_url      - URL for recording webhook (if record_calls)
   members            - List of dicts with 'dial_string' for each agent
@@ -438,13 +484,15 @@ Variables:
     <action application="set" data="execute_on_answer=record_session {{ recording_url }}/${uuid}.wav"/>
     {% endif %}
     <action application="set" data="fifo_music={{ moh }}"/>
-    {% if announce_position %}
-    <action application="set" data="fifo_orbit_announce_position=true"/>
-    {% endif %}
+    <!-- mod_fifo's max-wait is expressed as an orbit-exten with timeout in
+         the form "exten:seconds". Leaving the exten empty makes the caller
+         simply leave the fifo after <max_wait> seconds and fall through to
+         the next dialplan action (timeout_action below). -->
+    <action application="set" data="fifo_orbit_exten=:{{ max_wait }}"/>
     <action application="set" data="fifo_caller_exit_key=#"/>
     <action application="set" data="continue_on_fail=true"/>
     <action application="set" data="hangup_after_bridge=true"/>
-    <action application="fifo" data="{{ fifo_name }} in undef {{ moh }} {{ max_wait }}"/>
+    <action application="fifo" data="{{ fifo_name }} in undef {{ moh }}"/>
     {% if timeout_action == 'voicemail' and voicemail_user %}
     <action application="sleep" data="500"/>
     <action application="voicemail" data="default ${domain_name} {{ voicemail_user }}"/>
@@ -469,13 +517,15 @@ Variables:
     <action application="set" data="execute_on_answer=record_session {{ recording_url }}/${uuid}.wav"/>
     {% endif %}
     <action application="set" data="fifo_music={{ moh }}"/>
-    {% if announce_position %}
-    <action application="set" data="fifo_orbit_announce_position=true"/>
-    {% endif %}
+    <!-- mod_fifo's max-wait is expressed as an orbit-exten with timeout in
+         the form "exten:seconds". Leaving the exten empty makes the caller
+         simply leave the fifo after <max_wait> seconds and fall through to
+         the next dialplan action (timeout_action below). -->
+    <action application="set" data="fifo_orbit_exten=:{{ max_wait }}"/>
     <action application="set" data="fifo_caller_exit_key=#"/>
     <action application="set" data="continue_on_fail=true"/>
     <action application="set" data="hangup_after_bridge=true"/>
-    <action application="fifo" data="{{ fifo_name }} in undef {{ moh }} {{ max_wait }}"/>
+    <action application="fifo" data="{{ fifo_name }} in undef {{ moh }}"/>
     {% if timeout_action == 'voicemail' and voicemail_user %}
     <action application="sleep" data="500"/>
     <action application="voicemail" data="default ${domain_name} {{ voicemail_user }}"/>
@@ -784,6 +834,33 @@ Variables:
     {% endfor %}
   </fifos>
 </configuration>]]></field>
+    </record>
+
+    <record id="fs_template_dialplan_ivr_invalid" model="connect.freeswitch.template">
+        <field name="key">dialplan_ivr_invalid</field>
+        <field name="name">Dialplan - IVR Invalid Input</field>
+        <field name="section">dialplan</field>
+        <field name="description">Catch-all extension played when the caller dials a digit that does not
+match any IVR choice. Speaks invalid_input_message via Piper TTS and
+transfers the caller back into the IVR so they can try again.
+
+Variables:
+  callflow_id     - connect.callflow record ID
+  number          - The IVR's own extension number (target of the re-entry transfer)
+  lang            - Piper TTS language code
+  invalid_msg     - Text spoken to the caller before re-entry</field>
+        <field name="content"><![CDATA[<extension name="cf_invalid_{{ callflow_id }}">
+  <condition field="destination_number" expression="^cf_invalid_{{ callflow_id }}$" break="on-false">
+    <action application="speak" data="piper|{{ lang }}|{{ invalid_msg }}"/>
+    <action application="transfer" data="{{ number }} XML default"/>
+  </condition>
+</extension>]]></field>
+        <field name="default_content"><![CDATA[<extension name="cf_invalid_{{ callflow_id }}">
+  <condition field="destination_number" expression="^cf_invalid_{{ callflow_id }}$" break="on-false">
+    <action application="speak" data="piper|{{ lang }}|{{ invalid_msg }}"/>
+    <action application="transfer" data="{{ number }} XML default"/>
+  </condition>
+</extension>]]></field>
     </record>
 
 </odoo>

--- a/connect_freeswitch/models/fs_callflow.py
+++ b/connect_freeswitch/models/fs_callflow.py
@@ -17,8 +17,8 @@ class CallFlow(models.Model):
     def generate_dialplan(self, params, exten=None):
         """Generate FreeSWITCH dialplan XML for this callflow.
 
-        For IVR (gather_input): generates speak (TTS) + read (digit collection)
-        with inline condition branches for each choice.
+        For IVR (gather_input): generates bind_digit_action bindings plus speak (TTS)
+        so a DTMF press during the prompt instantly triggers the matching action.
         For ring groups (ring_users without gather): generates bridge to all users.
         """
         self.ensure_one()
@@ -37,57 +37,124 @@ class CallFlow(models.Model):
                     '</condition></extension>').format(
                         id=self.id, number=re.escape(number))
 
-    def _generate_ivr_dialplan(self, number):
-        """Generate IVR dialplan with speak + read and inline choice conditions."""
-        var_name = 'cf_digit_{}'.format(self.id)
-        min_digits = 1
-        max_digits = self.gather_digits or 1
-        timeout = (self.gather_timeout or 5) * 1000
-        prompt = self.prompt_message or ''
-        lang = self._get_piper_language()
-
-        fs_domain = self.env['connect.settings'].sudo().get_param('freeswitch_domain') or '${domain}'
-
+    def _ivr_choice_data(self):
+        """Build the list of {digits, dst_type, ...} dicts used by IVR templates."""
         choices = []
         for choice in self.choices:
             if not choice.choice_digits or not choice.exten:
                 continue
             dst = choice.exten.dst
             if dst and dst._name == 'connect.user':
-                user_number = dst.exten_number
                 choices.append({
-                    'digits_escaped': re.escape(choice.choice_digits),
+                    'digits': choice.choice_digits,
                     'dst_type': 'user',
                     'user_id': dst.id,
-                    'user_number': user_number,
+                    'user_number': dst.exten_number or '',
                     'transfer_target': '',
                 })
             else:
                 choices.append({
-                    'digits_escaped': re.escape(choice.choice_digits),
+                    'digits': choice.choice_digits,
                     'dst_type': 'other',
                     'user_id': '',
                     'user_number': '',
                     'transfer_target': choice.exten.number,
                 })
+        return choices
+
+    def _generate_ivr_dialplan(self, number):
+        """Generate IVR dialplan that uses bind_digit_action so DTMF interrupts speak."""
+        timeout = (self.gather_timeout or 5) * 1000
+        prompt = self.prompt_message or ''
+        lang = self._get_piper_language()
+
+        fs_domain = self.env['connect.settings'].sudo().get_param('freeswitch_domain') or '${domain}'
 
         fifo_number = ''
         if self.fs_fifo_id and self.fs_fifo_id.exten_number:
             fifo_number = self.fs_fifo_id.exten_number
+
+        ring_parts = []
+        for user in self.ring_users:
+            if user.exten_number:
+                ring_parts.append('user/{}@{}'.format(user.exten_number, fs_domain))
+        ring_bridge = ','.join(ring_parts)
+
+        choices = self._ivr_choice_data()
+
+        # gather_digits drives both the bind_digit_digit_timeout (inter-digit
+        # wait inside FreeSWITCH dmachine) and the invalid-input regex length.
+        # For single-digit IVRs we shrink the timeout to ~100ms so a press
+        # fires almost instantly instead of the 1500ms dmachine default.
+        gather_digits = max(int(self.gather_digits or 1), 1)
+        dmachine_timeout = 100 if gather_digits == 1 else 1500
+
+        invalid_msg = (self.invalid_input_message or '').strip()
+        invalid_regex = ''
+        if invalid_msg:
+            used_chars = set()
+            for choice in choices:
+                used_chars.update(choice['digits'])
+            allowed = [c for c in '0123456789*#' if c not in used_chars]
+            if allowed:
+                quant = '' if gather_digits == 1 else '{{1,{}}}'.format(gather_digits)
+                # FreeSWITCH digit parser treats `~` as a regex pattern.
+                # Match digits that are NOT among the bound choices, so exact
+                # bindings (1, 2, ...) win for valid input.
+                invalid_regex = '~^[{}]{}$'.format(''.join(allowed), quant)
 
         return self.env['connect.freeswitch.template'].render('dialplan_ivr', {
             'callflow_id': self.id,
             'number': re.escape(number),
             'lang': lang,
             'prompt': prompt,
-            'min_digits': min_digits,
-            'max_digits': max_digits,
             'timeout': timeout,
-            'var_name': var_name,
             'choices': choices,
             'fs_domain': fs_domain,
+            'ring_bridge': ring_bridge,
             'fifo_number': fifo_number,
+            'invalid_regex': invalid_regex,
+            'dmachine_timeout': dmachine_timeout,
         })
+
+    def _generate_ivr_invalid_dialplan(self):
+        """Generate the IVR catch-all extension that speaks invalid_input_message
+        and routes back into the IVR. Returns empty XML if no message is set."""
+        self.ensure_one()
+        msg = (self.invalid_input_message or '').strip()
+        if not msg:
+            return ''
+        number = self.exten_number or str(self.id)
+        return self.env['connect.freeswitch.template'].render(
+            'dialplan_ivr_invalid', {
+                'callflow_id': self.id,
+                'number': number,
+                'lang': self._get_piper_language(),
+                'invalid_msg': msg,
+            })
+
+    def _generate_ivr_choice_dialplan(self, digits):
+        """Generate dialplan for an IVR user-choice landing extension.
+
+        Called by the controller when FreeSWITCH routes destination=cf_call_<id>_<digits>
+        after a bind_digit_action fired. Returns an extension that sets the per-call
+        variables (so the Odoo event handler knows which user was rung) and bridges.
+        """
+        self.ensure_one()
+        for choice in self._ivr_choice_data():
+            if choice['digits'] == digits and choice['dst_type'] == 'user':
+                fs_domain = self.env['connect.settings'].sudo().get_param(
+                    'freeswitch_domain') or '${domain}'
+                return self.env['connect.freeswitch.template'].render(
+                    'dialplan_ivr_choice', {
+                        'callflow_id': self.id,
+                        'digits': digits,
+                        'digits_escaped': re.escape(digits),
+                        'user_id': choice['user_id'],
+                        'user_number': choice['user_number'],
+                        'fs_domain': fs_domain,
+                    })
+        return ''
 
     def _generate_ring_group_dialplan(self, number, exten=None):
         """Generate ring group dialplan bridging to multiple users."""

--- a/connect_freeswitch/models/fs_fifo.py
+++ b/connect_freeswitch/models/fs_fifo.py
@@ -24,10 +24,6 @@ class FsFifo(models.Model):
              'Defaults to the global `hold_music` variable defined in vars.xml '
              '(silence_stream://0 out of the box).',
     )
-    announce_position = fields.Boolean(
-        default=False,
-        help='Announce the caller position in the queue.',
-    )
     member_user_ids = fields.Many2many(
         'connect.user', 'fs_fifo_user_rel', 'fifo_id', 'user_id',
         string='User Agents',
@@ -118,7 +114,6 @@ class FsFifo(models.Model):
             'exten_id': exten.id if exten else None,
             'max_wait': self.max_wait_time or 60,
             'moh': self.moh_sound or '$${hold_music}',
-            'announce_position': bool(self.announce_position),
             'record_calls': bool(self.record_calls),
             'recording_url': recording_url,
             'members': members,

--- a/connect_freeswitch/views/fs_fifo_views.xml
+++ b/connect_freeswitch/views/fs_fifo_views.xml
@@ -35,7 +35,6 @@
                         <group string="Queue Behavior">
                             <field name="max_wait_time"/>
                             <field name="moh_sound"/>
-                            <field name="announce_position"/>
                         </group>
                     </group>
                     <group string="Timeout Action">

--- a/connect_twilio/__manifest__.py
+++ b/connect_twilio/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect Twilio',
-    'version': '19.0.1.1.0',
+    'version': '19.0.1.1.1',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'Twilio integration for Oduist Connect',

--- a/connect_twilio/models/callflow.py
+++ b/connect_twilio/models/callflow.py
@@ -12,6 +12,17 @@ logger = logging.getLogger(__name__)
 class CallFlow(models.Model):
     _inherit = 'connect.callflow'
 
+    # Twilio's Gather verb supports speech recognition in addition to DTMF.
+    # When this module is uninstalled, callflows that used a speech option
+    # fall back to DTMF.
+    gather_input_type = fields.Selection(
+        selection_add=[
+            ('speech', 'Speech'),
+            ('dtmf speech', 'DTMF + speech'),
+        ],
+        ondelete={'speech': 'set default', 'dtmf speech': 'set default'},
+    )
+
     gather_action_url = fields.Char(compute='_get_gather_action_url')
 
     def _get_gather_action_url(self):


### PR DESCRIPTION
## Summary

- IVR (`connect.callflow` with `gather_input`) is rewritten on top of FreeSWITCH `bind_digit_action`, so DTMF interrupts the Piper TTS prompt instantly and the chosen branch fires. User choices route through a new `cf_call_<id>_<digit>` landing extension that sets per-call variables and bridges; other destinations transfer directly. A `cf_invalid_<id>` catch-all speaks `invalid_input_message` and re-enters the IVR for unrecognised keypresses, and the post-prompt timeout falls back to `ring_users` and then to `fs_fifo_id`.
- `gather_input_type` selection in core is now DTMF-only; speech options moved to `connect_twilio` via `selection_add` (FreeSWITCH has no speech recogniser).
- Dialplan controller `_handle_dialplan` / `_route_internal` now prefers `Hunt-*` over `Caller-*` destination so in-call hops (`execute_extension` / `transfer`) resolve correctly to the IVR landing extensions instead of looping back to the original IVR number.
- Latency tuning: `bind_digit_digit_timeout` set explicitly (100 ms for single-digit menus, 1500 ms otherwise) — without it mod_dptools' dmachine adds a 1500 ms wait after every keypress.
- FS Queue (`mod_fifo`) dialplan no longer passes the queue timeout as the 5th `fifo` arg (mod_fifo reads that slot as answer-mode, so the timeout was a no-op and ``60`` ended up as junk data). The timeout is now enforced via `fifo_orbit_exten=:<sec>` so the caller leaves the queue cleanly after `max_wait`. The bogus `fifo_orbit_announce_position` variable and the matching `announce_position` UI checkbox / model field are removed — mod_fifo does not implement periodic position announcements, so the toggle was promising what the backend cannot deliver.

## Test plan

- [x] IVR call: press a valid digit → action fires immediately, no need to wait for the prompt to finish.
- [x] IVR call: press an invalid digit → ``invalid_input_message`` plays, IVR restarts.
- [x] IVR call: wait through ``gather_timeout`` → caller bridges to ``ring_users`` (then to ``fs_fifo_id`` on failure / if no ring_users).
- [x] FS Queue: caller is held in the queue with the configured MoH (verified with ``tone_stream://%(2000,4000,440,480);loops=-1``) until ``max_wait`` elapses, then proceeds to ``timeout_action``.
- [ ] FS Queue: replace MoH default with a stream that is actually shipped in the ``oduist/freeswitch`` image (separate follow-up — ``mod_local_stream`` not loaded in current image; default ``local_stream://moh`` crashes the channel).