### PR TITLE
feat(freeswitch): enable mod_local_stream + ship MoH out of the box (backport of #85)

### DIFF
--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '18.0.1.8.21',
+    'version': '18.0.1.8.22',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',

--- a/connect_freeswitch/deploy/Dockerfile
+++ b/connect_freeswitch/deploy/Dockerfile
@@ -73,6 +73,7 @@ applications/mod_dptools
 applications/mod_http_cache
 applications/mod_fifo
 applications/mod_valet_parking
+formats/mod_local_stream
 dialplans/mod_dialplan_xml
 codecs/mod_opus
 formats/mod_sndfile
@@ -147,10 +148,15 @@ COPY --from=builder /opt/piper /opt/piper
 
 RUN ldconfig
 
-# Required runtime directories
+# Required runtime directories. The entrypoint downloads sound tarballs into
+# /usr/share/freeswitch/sounds (mounted as a volume), but mod_local_stream
+# resolves $${sounds_dir} which points inside the FreeSWITCH prefix, so we
+# expose the same path under both locations via a symlink.
 RUN mkdir -p /usr/local/freeswitch/var/run/freeswitch \
              /usr/local/freeswitch/var/log/freeswitch \
-             /usr/share/freeswitch/sounds
+             /usr/share/freeswitch/sounds \
+    && rm -rf /usr/local/freeswitch/share/freeswitch/sounds \
+    && ln -s /usr/share/freeswitch/sounds /usr/local/freeswitch/share/freeswitch/sounds
 
 # Convenience symlinks
 RUN ln -sf /usr/local/freeswitch/bin/freeswitch /usr/bin/freeswitch \
@@ -165,7 +171,7 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 
 ENV ODOO_URL=http://localhost:8069 \
-    SOUND_RATES=8000:16000 \
+    SOUND_RATES=8000:16000:32000:48000 \
     SOUND_TYPES=music:en-us-callie \
     EPMD=false \
     DUMPCAP=false \

--- a/connect_freeswitch/deploy/freeswitch/conf/autoload_configs/local_stream.conf.xml
+++ b/connect_freeswitch/deploy/freeswitch/conf/autoload_configs/local_stream.conf.xml
@@ -1,0 +1,45 @@
+<configuration name="local_stream.conf" description="Stream music-on-hold files from disk">
+  <!--
+    The entrypoint downloads `freeswitch-sounds-music-<rate>-*.tar.gz` into
+    $${sounds_dir}/music/<rate>/ (SOUND_TYPES=music, SOUND_RATES=8000:16000
+    by default — see Dockerfile). mod_local_stream picks the closest matching
+    rate at runtime; if a rate folder is empty the stream stays silent and
+    the call still goes through.
+  -->
+  <directory name="moh/8000" path="$${sounds_dir}/music/8000">
+    <param name="rate" value="8000"/>
+    <param name="shuffle" value="true"/>
+    <param name="channels" value="1"/>
+    <param name="interval" value="20"/>
+    <param name="timer-name" value="soft"/>
+    <param name="chime-time" value="0"/>
+    <param name="chime-max" value="0"/>
+  </directory>
+  <directory name="moh/16000" path="$${sounds_dir}/music/16000">
+    <param name="rate" value="16000"/>
+    <param name="shuffle" value="true"/>
+    <param name="channels" value="1"/>
+    <param name="interval" value="20"/>
+    <param name="timer-name" value="soft"/>
+    <param name="chime-time" value="0"/>
+    <param name="chime-max" value="0"/>
+  </directory>
+  <directory name="moh/32000" path="$${sounds_dir}/music/32000">
+    <param name="rate" value="32000"/>
+    <param name="shuffle" value="true"/>
+    <param name="channels" value="1"/>
+    <param name="interval" value="20"/>
+    <param name="timer-name" value="soft"/>
+    <param name="chime-time" value="0"/>
+    <param name="chime-max" value="0"/>
+  </directory>
+  <directory name="moh/48000" path="$${sounds_dir}/music/48000">
+    <param name="rate" value="48000"/>
+    <param name="shuffle" value="true"/>
+    <param name="channels" value="1"/>
+    <param name="interval" value="20"/>
+    <param name="timer-name" value="soft"/>
+    <param name="chime-time" value="0"/>
+    <param name="chime-max" value="0"/>
+  </directory>
+</configuration>

--- a/connect_freeswitch/deploy/freeswitch/conf/autoload_configs/modules.conf.xml
+++ b/connect_freeswitch/deploy/freeswitch/conf/autoload_configs/modules.conf.xml
@@ -25,6 +25,7 @@
     <load module="mod_dialplan_xml"/>
     <load module="mod_fifo"/>
     <load module="mod_valet_parking"/>
+    <load module="mod_local_stream"/>
 
     <!-- Codecs -->
     <load module="mod_opus"/>

--- a/connect_freeswitch/deploy/freeswitch/conf/vars.xml
+++ b/connect_freeswitch/deploy/freeswitch/conf/vars.xml
@@ -21,7 +21,14 @@
   <X-PRE-PROCESS cmd="set" data="internal_ssl_enable=false"/>
   <X-PRE-PROCESS cmd="set" data="internal_auth_calls=true"/>
 
-  <X-PRE-PROCESS cmd="set" data="hold_music=silence_stream://-1"/>
+  <!--
+    Hold music feeds mod_fifo's queue MoH, the bridge-on-hold prompt, etc.
+    `local_stream://moh` streams the royalty-free music package downloaded by
+    the entrypoint (see SOUND_TYPES=music in the Dockerfile). Override here
+    or per-call (e.g. `set fifo_music=...`) when the operator wants a
+    different source.
+  -->
+  <X-PRE-PROCESS cmd="set" data="hold_music=local_stream://moh"/>
   <X-PRE-PROCESS cmd="set" data="use_profile=internal"/>
   <!-- Log levels: read from Docker env vars (defaults in Dockerfile) -->
   <X-PRE-PROCESS cmd="env-set" data="core_loglevel=$FS_LOG_LEVEL"/>


### PR DESCRIPTION
Backport of #85 to the 18.0 series. Same Docker image (\`oduist/freeswitch:1.8.22 / :latest\`) serves both 18.0 and 19.0; only the manifest version prefix differs.

## Summary

- Compile \`formats/mod_local_stream\` into the FreeSWITCH image and load it from \`modules.conf.xml\`.
- New \`autoload_configs/local_stream.conf.xml\` exposing a \`moh\` stream backed by the music sound packs the entrypoint downloads. Four \`<directory>\` entries (8000/16000/32000/48000 kHz) so Verto/WebRTC callers on opus@48000 also get audible MoH.
- Extend Dockerfile \`SOUND_RATES=8000:16000:32000:48000\`.
- Symlink \`/usr/local/freeswitch/share/freeswitch/sounds\` → \`/usr/share/freeswitch/sounds\` so the FS prefix and the volume path are the same directory.
- Flip the default \`hold_music\` to \`local_stream://moh\` in \`vars.xml\`.
- Bump \`connect_freeswitch\` manifest to \`18.0.1.8.22\`.

## Cross-branch versioning

| Module | 18.0 | 19.0 |
| --- | --- | --- |
| connect_freeswitch | 18.0.1.8.22 | 19.0.1.8.22 |

## Test plan

- [ ] Smoke test on an 18.0 oduflow env: \`module_exists mod_local_stream\` → \`true\`; FS Queue caller (Verto/opus@48000) hears music while waiting.