### PR TITLE
fix(freeswitch): honor outgoing_callerid for external outbound calls (#89)

### DIFF
--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.9.0',
+    'version': '19.0.1.9.1',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',

--- a/connect_freeswitch/models/call.py
+++ b/connect_freeswitch/models/call.py
@@ -180,13 +180,21 @@ class Call(models.Model):
 
         a_leg = ','.join(a_leg_parts)
 
-        # Caller ID for b-leg (what the called party sees)
-        first_ep = endpoints[:1]
-        caller_number = connect_user.exten_number or (first_ep.auth_user if first_ep else '')
-
         # Check if target is an internal extension
         exten = self.env['connect.exten'].search(
             [('number', '=', number)], limit=1)
+
+        # Caller ID for b-leg (what the called party sees)
+        first_ep = endpoints[:1]
+        if exten:
+            caller_number = connect_user.exten_number or (first_ep.auth_user if first_ep else '')
+        else:
+            caller_number = (
+                connect_user.outgoing_callerid.number
+                or connect_user.exten_number
+                or (first_ep.auth_user if first_ep else '')
+            )
+
         if exten:
             # Internal call — bridge to extension's destination
             b_leg = self._build_internal_b_leg(exten, domain)


### PR DESCRIPTION
## Summary
- Fixes [#89](https://github.com/oduist/connect_addons_ng/issues/89): outbound calls always showed the user's internal extension to the callee, ignoring `connect.user.outgoing_callerid`.
- `connect_freeswitch/models/call.py`: for **external** outbound calls, b-leg caller ID now follows the priority chain `outgoing_callerid.number → exten_number → first endpoint's auth_user`. **Internal** extension-to-extension calls are unchanged — they continue to show the initiator's extension (standard PBX UX).
- `connect_freeswitch` version bumped to `19.0.1.9.1`. No schema change, no migration script.

## Test plan
Verified end-to-end in oduflow env `beirut` (template `fs19-dev`) by mocking `connect.settings.freeswitch_api` and capturing the generated FS originate command. The `origination_caller_id_number` in the command was:

| Scenario | Result | Expected |
|---|---|---|
| External call, no `outgoing_callerid` | `101` (exten_number) | exten_number fallback |
| External call, `outgoing_callerid = +41215121141` | `+41215121141` | DID |
| Internal call to ext `102`, `outgoing_callerid` set | `101` (exten_number) | exten_number (PBX UX) |

## Notes
- Related: #88 — without `connect_twilio` installed, the `outgoing_callerid` field's domain (`status = 'validated'`) crashes the user form because `status` is added by `connect_twilio`. That remains a separate fix and is required for pure-FreeSWITCH installs to be able to pick a DID through the UI.
- An 18.0 backport will follow as a separate PR after this lands (manifest aligned to `18.0.1.9.1`).