### PR TITLE
fix(connect): drop Twilio-only status leaf from outgoing_callerid domain (#88)

### DIFF
--- a/connect/__manifest__.py
+++ b/connect/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect',
-    'version': '19.0.3.1.2',
+    'version': '19.0.3.1.3',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'Communication platform for Odoo',

--- a/connect/models/user.py
+++ b/connect/models/user.py
@@ -26,7 +26,7 @@ class User(models.Model):
     voicemail_prompt = fields.Text(
         default="Hello, this is {{user.name}}. I'm unable to take your call right now. Please leave a message after the tone.")
     outgoing_callerid = fields.Many2one('connect.outgoing_callerid', ondelete='set null',
-        domain=['|', ('status', '=', 'validated'), ('callerid_type', '=', 'number')])
+        domain=[('callerid_type', '=', 'number')])
     missed_calls_notify = fields.Boolean(default=False, help='Notify user on missed calls.')
     greeting_message = fields.Char()
     summary_prompt = fields.Char()

--- a/connect_twilio/__manifest__.py
+++ b/connect_twilio/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect Twilio',
-    'version': '19.0.1.1.1',
+    'version': '19.0.1.1.2',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'Twilio integration for Oduist Connect',

--- a/connect_twilio/views/user_views.xml
+++ b/connect_twilio/views/user_views.xml
@@ -29,6 +29,12 @@
             <xpath expr="//field[@name='user']" position="after">
                 <field name="username"/>
             </xpath>
+
+            <!-- Twilio adds the `status` field on connect.outgoing_callerid; -->
+            <!-- restrict picker to validated CallerIDs or DID numbers. -->
+            <xpath expr="//field[@name='outgoing_callerid']" position="attributes">
+                <attribute name="domain">['|', ('status', '=', 'validated'), ('callerid_type', '=', 'number')]</attribute>
+            </xpath>
             <xpath expr="//field[@name='active']" position="after">
                 <field name="domain"/>
                 <field name="twilio_edge"

--- a/specs/connect_core.md
+++ b/specs/connect_core.md
@@ -313,7 +313,7 @@ Order: `name`
 | `record_calls` | Boolean | Default: True |
 | `voicemail_enabled` | Boolean | |
 | `voicemail_prompt` | Text | Jinja2 template |
-| `outgoing_callerid` | Many2one | `connect.outgoing_callerid` |
+| `outgoing_callerid` | Many2one | `connect.outgoing_callerid`, domain `[('callerid_type', '=', 'number')]` (provider modules may further restrict via view-inheritance, e.g. Twilio adds the `status='validated'` filter) |
 | `missed_calls_notify` | Boolean | |
 | `greeting_message` | Char | |
 | `summary_prompt` | Char | Per-user override |

--- a/specs/connect_twilio.md
+++ b/specs/connect_twilio.md
@@ -487,7 +487,7 @@ Default WhatsApp content template: `voice_call_request` - used for voice call co
 | File | Inherits | Changes |
 |------|----------|---------|
 | `views/settings_views.xml` | `connect.connect_settings_form` | Add Twilio balance group, API keys page, development page, fetch_call_prices |
-| `views/user_views.xml` | `connect.view_connect_user_form`, `connect.view_connect_user_tree` | Add SIP/Client phone tab, domain, edge, whatsapp_sender, application; list adds sip_enabled/client_enabled columns |
+| `views/user_views.xml` | `connect.view_connect_user_form`, `connect.view_connect_user_tree` | Add SIP/Client phone tab, domain, edge, whatsapp_sender, application; list adds sip_enabled/client_enabled columns; override `outgoing_callerid` domain to require `status='validated'` (Twilio-only field) |
 | `views/number_views.xml` | `connect.view_connect_number_form`, `connect.view_connect_number_tree` | Add twiml routing option and twiml column |
 | `views/outgoing_callerid_views.xml` | `connect.view_connect_outgoing_callerid_form` | Add Validate button and validation_code field |
 

--- a/specs/decisions/019-outgoing-callerid-domain-boundary.md
+++ b/specs/decisions/019-outgoing-callerid-domain-boundary.md
@@ -1,0 +1,86 @@
+# ADR-019: `connect.user.outgoing_callerid` domain — provider boundary fix
+
+## Status
+Accepted
+
+## Context
+
+GitHub issue [#88](https://github.com/oduist/connect_addons_ng/issues/88).
+
+The core model `connect.user` defined the `outgoing_callerid` Many2one
+with a domain that referenced a Twilio-only field:
+
+```python
+# connect/models/user.py (before)
+outgoing_callerid = fields.Many2one(
+    'connect.outgoing_callerid', ondelete='set null',
+    domain=['|', ('status', '=', 'validated'),
+            ('callerid_type', '=', 'number')])
+```
+
+The `status` field is added to `connect.outgoing_callerid` only by
+`connect_twilio` (`connect_twilio/models/outgoing_callerid.py:16`). On a
+FreeSWITCH-only deployment (or any deployment without `connect_twilio`)
+the ORM raises `ValueError: Invalid field connect.outgoing_callerid.status
+in leaf ('status', '=', 'validated')` whenever the domain is evaluated —
+e.g. when opening the user form or the field's dropdown. The
+`connect.user` form was therefore unusable for FreeSWITCH-only users.
+
+This also broke a core architectural rule (see `CLAUDE.md` /
+`specs/architecture.md`): **the `connect` core never references
+provider-specific fields or concepts**. `status` describes the Twilio
+Outgoing CallerID validation lifecycle; it does not exist in the
+provider-agnostic data model.
+
+## Decision
+
+1. **Drop the `status` leaf from the core domain.** The core domain on
+   `connect.user.outgoing_callerid` is now provider-agnostic:
+
+   ```python
+   outgoing_callerid = fields.Many2one(
+       'connect.outgoing_callerid', ondelete='set null',
+       domain=[('callerid_type', '=', 'number')])
+   ```
+
+2. **Restore the validated-only filter in Twilio via view-inheritance.**
+   `connect_twilio/views/user_views.xml` overrides the field's `domain`
+   attribute on the form so that, when Twilio is installed, the picker
+   shows only validated outgoing CallerIDs or DID numbers:
+
+   ```xml
+   <xpath expr="//field[@name='outgoing_callerid']" position="attributes">
+       <attribute name="domain">
+           ['|', ('status', '=', 'validated'),
+                 ('callerid_type', '=', 'number')]
+       </attribute>
+   </xpath>
+   ```
+
+## Alternatives considered
+
+- **Declare a no-op `status` field in core.** Rejected — leaks a
+  Twilio-specific concept into the provider-agnostic layer, the exact
+  thing the architecture forbids.
+- **Compute the domain dynamically in Python.** Rejected — needless
+  complexity for a single attribute. Odoo's `position="attributes"` is
+  the idiomatic extension point.
+- **Drop the domain altogether.** Rejected — the Twilio UX needs to hide
+  unverified caller IDs from the picker, otherwise users can select
+  records Twilio will reject at call time.
+
+## Cross-branch backport
+
+Per `CLAUDE.md` versioning rules, the same change must be ported to the
+`18.0` branch with aligned tail versions (`18.0.3.1.3` for `connect`,
+`18.0.1.1.2` for `connect_twilio`). The backport ships as a separate PR.
+
+## Consequences
+
+- FreeSWITCH-only deployments can open the `connect.user` form and
+  select an outgoing caller ID.
+- Twilio deployments preserve the previous filter — no UX regression in
+  the picker.
+- The reverse-domain restriction now lives in view metadata, not in the
+  model, mirroring the rest of the Twilio extension surface (extra
+  fields are added via `_inherit`, extra UI via view inheritance).


### PR DESCRIPTION
## Summary

- Removes the Twilio-only `('status', '=', 'validated')` leaf from the `connect.user.outgoing_callerid` domain in core. On FreeSWITCH-only deployments the ORM was raising `ValueError: Invalid field connect.outgoing_callerid.status` whenever the field's domain was evaluated, breaking the `connect.user` form entirely.
- Restores the validated-only filter inside `connect_twilio` via view-inheritance (`position=\"attributes\"`), so the picker UX is unchanged when Twilio is installed.
- Adds ADR-019 and updates `specs/connect_core.md` / `specs/connect_twilio.md`. Bumps `connect` to `19.0.3.1.3` and `connect_twilio` to `19.0.1.1.2`.

Closes #88.

## Test plan

- [x] Provision oduflow env `issue-88` from this branch (template `fs19-dev`, `connect` + `connect_freeswitch` installed, **no** `connect_twilio`).
- [x] **Scenario A — without Twilio**: confirm `connect.user._fields['outgoing_callerid'].domain == [('callerid_type', '=', 'number')]`, `status` field absent on `connect.outgoing_callerid`, `name_search(domain=...)` returns only DID numbers — no `ValueError`.
- [x] **Scenario B — with Twilio**: install `connect_twilio`; confirm Python `field.domain` stays provider-agnostic, but the combined form arch renders `<field name=\"outgoing_callerid\" domain=\"['|', ('status', '=', 'validated'), ('callerid_type', '=', 'number')]\"/>` — the validated filter is restored through view-inheritance.
- [ ] Backport to `18.0` will land as a separate PR (tail versions `18.0.3.1.3` / `18.0.1.1.2`, per CLAUDE.md cross-branch rule).

## Notes

While installing Twilio on top of an existing FreeSWITCH-only DB I hit an unrelated pre-existing issue in `connect_twilio/models/user.py:64-71` — the `domain` Many2one's `default=lambda` queries `connect.domain` before its table exists, causing `UndefinedTable` when there are pre-existing `connect.user` rows. Worked around it during verification by deleting the existing rows; will open a separate issue/PR.