### PR TITLE
fix(freeswitch): honor outgoing_callerid for external outbound calls (port of #90)

### DIFF
--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '18.0.1.9.0',
+    'version': '18.0.1.9.1',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',

--- a/connect_freeswitch/models/call.py
+++ b/connect_freeswitch/models/call.py
@@ -180,13 +180,21 @@ class Call(models.Model):
 
         a_leg = ','.join(a_leg_parts)
 
-        # Caller ID for b-leg (what the called party sees)
-        first_ep = endpoints[:1]
-        caller_number = connect_user.exten_number or (first_ep.auth_user if first_ep else '')
-
         # Check if target is an internal extension
         exten = self.env['connect.exten'].search(
             [('number', '=', number)], limit=1)
+
+        # Caller ID for b-leg (what the called party sees)
+        first_ep = endpoints[:1]
+        if exten:
+            caller_number = connect_user.exten_number or (first_ep.auth_user if first_ep else '')
+        else:
+            caller_number = (
+                connect_user.outgoing_callerid.number
+                or connect_user.exten_number
+                or (first_ep.auth_user if first_ep else '')
+            )
+
         if exten:
             # Internal call — bridge to extension's destination
             b_leg = self._build_internal_b_leg(exten, domain)


### PR DESCRIPTION
## Summary
Port of [#90](https://github.com/oduist/connect_addons_ng/pull/90) to the 18.0 branch. Fixes issue [#89](https://github.com/oduist/connect_addons_ng/issues/89).

- `connect_freeswitch/models/call.py`: for external outbound calls, b-leg caller ID now follows `outgoing_callerid.number → exten_number → first endpoint's auth_user`. Internal extension-to-extension calls are unchanged.
- Manifest aligned: `18.0.1.9.0` → `18.0.1.9.1` (matches `19.0.1.9.1`).
- No schema change, no migration.

## Test plan
Deployed to oduflow env `beirut-18` (template `fs18-dev`):
- Module upgrade succeeded with no errors.
- Patched source on disk inspected — block matches the 19.0 fix word-for-word.
- Runtime originate scenarios (external no DID / external with DID / internal with DID) were exercised end-to-end on `beirut` (19.0) — see #90 — and the code path here is byte-identical, so the same three outcomes apply.