### PR TITLE
docs(claude): clean up backport branches once PR is open (port of #94)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,14 @@ differs. Concretely:
   Python migration script, both branches should call the same module
   function (e.g. `setup_firewall(env)`), with the per-series migration
   folder acting purely as the entry point Odoo can match.
+- **Clean up the backport branch as soon as the PR is open.** After
+  `gh pr create` returns the backport PR URL, automatically:
+  1. `git worktree remove <path>` if a worktree was used for the port;
+  2. `git branch -D <port-branch>` to drop the local ref;
+  3. leave the remote branch in place — it backs the PR and GitHub
+     deletes it on merge (repo has "Automatically delete head branches"
+     enabled).
+  Do this without asking; treat it as part of the backport workflow.
 
 ## Conventions
 


### PR DESCRIPTION
## Summary
Port of [#94](https://github.com/oduist/connect_addons_ng/pull/94) to the 18.0 branch. Adds the same workflow rule to `CLAUDE.md` under **Cross-branch versioning rules**: after `gh pr create` returns the backport PR URL, the agent automatically removes the local worktree and deletes the local branch ref. The remote branch stays in place to back the PR; GitHub drops it on merge (the repo has \"Automatically delete head branches\" enabled).

## Test plan
- N/A — docs-only change. Identical wording to #94.