### PR TITLE
fix(freeswitch): outgoing CallerID on UA-originated PSTN calls + CDR cleanup (port of #99)

### DIFF
--- a/.oduflow/odoo.conf
+++ b/.oduflow/odoo.conf
@@ -5,4 +5,4 @@ max_cron_threads = 1
 limit_time_cpu = 600
 limit_time_real = 1200
 db_maxconn=16
-workers=0
+workers=3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,32 @@ differs. Concretely:
      enabled).
   Do this without asking; treat it as part of the backport workflow.
 
+### Bump the manifest version at most once per session / feature branch
+
+A `__manifest__.py` `version` bump represents one logical release unit
+of the module — the same unit that ships as one PR. **Bump it at most
+once per working session / feature branch, regardless of how many
+intermediate fix commits the branch contains.** Multiple bumps within
+one branch are wrong: they produce noisy history, force you to flatten
+versions before merge, and have no functional effect.
+
+Specifically:
+- Do **not** bump the version on every commit. Bug-fix commits in
+  controllers / models / data are picked up by `pull_and_apply` via
+  diff analysis (Python → restart, schema/field change → upgrade,
+  views/assets → hot-reload); none of these require the manifest to
+  change.
+- Do **not** create a standalone "chore: bump version" commit. If the
+  bump is needed for a release, fold it into the last functional
+  commit or a single cleanup commit at the end of the branch.
+- The version moves on **release boundaries**, not on commit
+  boundaries. Inside one session the bump should land once — typically
+  in the first commit that changes module behavior, or in a final
+  cleanup pass just before opening the PR.
+- If you realise mid-session that you already bumped the version,
+  leave it alone and keep working at that target version; do not bump
+  again.
+
 ## Conventions
 
 - Models follow `connect.<name>` naming (e.g., `connect.call`, `connect.recording`)

--- a/connect/__manifest__.py
+++ b/connect/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect',
-    'version': '18.0.3.1.3',
+    'version': '18.0.3.1.4',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'Communication platform for Odoo',

--- a/connect/models/outgoing_callerid.py
+++ b/connect/models/outgoing_callerid.py
@@ -9,6 +9,7 @@ class OutgoingCallerID(models.Model):
     _name = 'connect.outgoing_callerid'
     _description = 'Outgoing CallerId'
     _order = 'number'
+    _rec_names_search = ['number', 'friendly_name']
 
     name = fields.Char(compute='_get_name')
     friendly_name = fields.Char(required=True)

--- a/connect/models/user.py
+++ b/connect/models/user.py
@@ -25,8 +25,7 @@ class User(models.Model):
     voicemail_enabled = fields.Boolean()
     voicemail_prompt = fields.Text(
         default="Hello, this is {{user.name}}. I'm unable to take your call right now. Please leave a message after the tone.")
-    outgoing_callerid = fields.Many2one('connect.outgoing_callerid', ondelete='set null',
-        domain=[('callerid_type', '=', 'number')])
+    outgoing_callerid = fields.Many2one('connect.outgoing_callerid', ondelete='set null')
     missed_calls_notify = fields.Boolean(default=False, help='Notify user on missed calls.')
     greeting_message = fields.Char()
     summary_prompt = fields.Char()

--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '18.0.1.9.1',
+    'version': '18.0.1.9.3',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',

--- a/connect_freeswitch/controllers/freeswitch_cdr.py
+++ b/connect_freeswitch/controllers/freeswitch_cdr.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import urllib.parse
 from xml.etree import ElementTree as ET
 
 from odoo import http
@@ -75,12 +76,21 @@ class FreeSwitchCDRController(http.Controller):
         caller_profile = root.find('.//caller_profile')
         caller = ''
         called = ''
-        direction = 'inbound'
 
         if caller_profile is not None:
             caller = self._xml_text(caller_profile, 'caller_id_number')
             called = self._xml_text(caller_profile, 'destination_number')
-            direction = self._xml_text(caller_profile, 'direction', 'inbound')
+
+        # FreeSWITCH stores the channel's direction in <channel_data>
+        # at the top of the CDR — `inbound` for the originator (UA → FS)
+        # leg, `outbound` for the gateway (FS → PSTN) leg. The previous
+        # XPath (`caller_profile/direction`) never matched in any FS
+        # version, so every CDR was parsed as `inbound`.
+        channel_data = root.find('./channel_data')
+        if channel_data is not None:
+            direction = self._xml_text(channel_data, 'direction', 'inbound')
+        else:
+            direction = 'inbound'
 
         # Hangup cause
         hangup_cause = self._xml_text(root, './/hangup_cause', 'NORMAL_CLEARING')
@@ -107,28 +117,70 @@ class FreeSwitchCDRController(http.Controller):
         odoo_number_id = None
 
         if variables is not None:
-            # Use effective_caller_id_number (set by Odoo directory) if
-            # caller_id_number is a SIP username rather than a number
-            effective_caller = self._xml_text(
-                variables, 'effective_caller_id_number')
-            if effective_caller and not caller.isdigit():
+            # Click-to-call originates `user/<login>@<domain>` and the
+            # user directory rewrites the channel's effective caller-id
+            # back to the extension, silently overriding any globals
+            # `connect.call.originate` tried to set. The originate path
+            # therefore stashes the intended caller-id on the custom
+            # `odoo_caller_id_number` variable — prefer that. UA-
+            # originated calls don't set it; they get the right value
+            # from `effective_caller_id_number` (rewritten by the
+            # outgoing-route dialplan, ADR-021).
+            #
+            # mod_xml_cdr URL-encodes channel variable values inside
+            # <variables> (`+` → `%2B`, `@` → `%40`), so unquote first.
+            odoo_caller_id = urllib.parse.unquote(self._xml_text(
+                variables, 'odoo_caller_id_number'))
+            effective_caller = urllib.parse.unquote(self._xml_text(
+                variables, 'effective_caller_id_number'))
+            if odoo_caller_id:
+                caller = odoo_caller_id
+            elif effective_caller:
                 caller = effective_caller
 
+            # Click-to-call originates `user/<login>@<domain>`, so the
+            # A-leg's caller_profile.destination_number is the resolved
+            # user URI rather than the dialled number. The originate
+            # path stashes the real destination as a channel variable;
+            # use it when present.
+            odoo_destination = urllib.parse.unquote(self._xml_text(
+                variables, 'odoo_destination_number'))
+            if odoo_destination:
+                called = odoo_destination
+
+            # B-leg discriminator: mod_xml_cdr always sets `originator`
+            # (and `originating_leg_uuid`) on the originatee side; the
+            # originator does not have them. `bridge_uuid` / `signal_bond`
+            # are present on both legs and are NOT reliable for A/B
+            # detection.
+            originator_uuid = (
+                self._xml_text(variables, 'originator')
+                or self._xml_text(variables, 'originating_leg_uuid')
+            )
+
+            # `other_leg_uuid` drives parent-channel linking in
+            # `connect.channel.process_channel_event`. We populate it
+            # only on the B-leg (= originatee) so the A-leg has no
+            # parent. The A-leg picks up its B-leg via the reverse-orphan
+            # check in `connect.call.on_freeswitch_cdr` once the B-leg
+            # CDR arrives.
             other_leg_uuid = (
                 self._xml_text(variables, 'odoo_parent_uuid')
                 or self._xml_text(variables, 'Other-Leg-Unique-ID')
+                or originator_uuid
             )
 
             odoo_user = self._xml_text(variables, 'odoo_connect_user_id')
             odoo_called_user = self._xml_text(
                 variables, 'odoo_called_user_id')
-            if other_leg_uuid:
-                # B-leg: odoo_connect_user_id is the called user
+            if originator_uuid:
+                # B-leg: odoo_connect_user_id (if present) identifies the
+                # called connect.user.
                 if odoo_user:
                     called_pbx_user_id = int(odoo_user)
             else:
                 # A-leg: odoo_connect_user_id is the caller,
-                # odoo_called_user_id is the called user
+                # odoo_called_user_id is the called user.
                 if odoo_user:
                     caller_pbx_user_id = int(odoo_user)
                 if odoo_called_user:

--- a/connect_freeswitch/data/fs_templates.xml
+++ b/connect_freeswitch/data/fs_templates.xml
@@ -427,11 +427,17 @@ Variables:
 Variables:
   route_id        - connect.freeswitch.outgoing_route record ID
   pattern         - Regex pattern for destination matching
-  bridge_data     - Bridge string (sofia/gateway/name/number)</field>
+  bridge_data     - Bridge string (sofia/gateway/name/number)
+  cid_name        - Caller ID name to present on PSTN (from connect.user.outgoing_callerid)
+  cid_num         - Caller ID number to present on PSTN (from connect.user.outgoing_callerid)</field>
         <field name="content"><![CDATA[<extension name="outgoing_{{ route_id }}">
   <condition field="destination_number" expression="{{ pattern }}">
     <action application="set" data="odoo_call_direction=outgoing"/>
     <action application="export" data="nolocal:absolute_codec_string=PCMU,PCMA"/>
+    {% if cid_num %}
+    <action application="set" data="effective_caller_id_number={{ cid_num }}"/>
+    <action application="set" data="effective_caller_id_name={{ cid_name }}"/>
+    {% endif %}
     <action application="bridge" data="{{ bridge_data }}"/>
   </condition>
 </extension>]]></field>
@@ -439,6 +445,10 @@ Variables:
   <condition field="destination_number" expression="{{ pattern }}">
     <action application="set" data="odoo_call_direction=outgoing"/>
     <action application="export" data="nolocal:absolute_codec_string=PCMU,PCMA"/>
+    {% if cid_num %}
+    <action application="set" data="effective_caller_id_number={{ cid_num }}"/>
+    <action application="set" data="effective_caller_id_name={{ cid_name }}"/>
+    {% endif %}
     <action application="bridge" data="{{ bridge_data }}"/>
   </condition>
 </extension>]]></field>

--- a/connect_freeswitch/deploy/freeswitch/conf/autoload_configs/xml_cdr.conf.xml
+++ b/connect_freeswitch/deploy/freeswitch/conf/autoload_configs/xml_cdr.conf.xml
@@ -3,7 +3,7 @@
     <param name="url" value="$${odoo_url}/freeswitch/webhook/cdr"/>
     <param name="retries" value="2"/>
     <param name="delay" value="5"/>
-    <param name="log-b-leg" value="true"/>
+    <param name="log-b-leg" value="false"/>
     <param name="prefix-a-leg" value="true"/>
     <param name="encode" value="true"/>
     <param name="err-log-dir" value="/var/log/freeswitch/xml_cdr"/>

--- a/connect_freeswitch/models/call.py
+++ b/connect_freeswitch/models/call.py
@@ -216,19 +216,43 @@ class Call(models.Model):
                     "No outgoing route found for number: {}".format(number))
 
         # Build originate command
+        cid_name = (caller_name or caller_number).replace("'", "")
         variables = [
-            "origination_caller_id_name='{}'".format(
-                (caller_name or caller_number).replace("'", "")),
+            "origination_caller_id_name='{}'".format(cid_name),
             "origination_caller_id_number={}".format(caller_number),
             "odoo_caller_pbx_user_id={}".format(connect_user.id),
+            # `originate user/<login>@<domain>` makes the A-leg's
+            # caller_profile.destination_number the resolved user URI
+            # (e.g. "u:<verto-uuid>"), not the dialled number. Stash
+            # the real destination so the CDR parser can recover it.
+            "odoo_destination_number={}".format(number),
+            # The A-leg goes through the user directory, which seeds
+            # effective_caller_id_* from the user's extension and
+            # silently overrides any globals we try to set. Stash the
+            # intended caller-id on a custom variable that the CDR
+            # parser can pick up — symmetric with the dialplan SET
+            # that UA-originated calls do via ADR-021.
+            "odoo_caller_id_name='{}'".format(cid_name),
+            "odoo_caller_id_number={}".format(caller_number),
         ]
         if partner_id:
             variables.append("odoo_partner_id={}".format(partner_id))
 
+        # B-leg caller-id: the bridge subchannel that actually reaches
+        # the PSTN gateway (or the called user for internal calls)
+        # inherits its caller-id from the A-leg by default, which is
+        # the directory-seeded extension. Override on the B-leg itself
+        # so the called party sees `caller_number` (extension for
+        # internal, outgoing_callerid for external).
+        b_leg_vars = [
+            "origination_caller_id_name='{}'".format(cid_name),
+            "origination_caller_id_number={}".format(caller_number),
+        ]
         # For external calls via gateway, force standard codecs on b-leg
         # since a-leg may be WebRTC (Opus) which gateways don't support
         if not exten:
-            b_leg = '[absolute_codec_string=PCMU,PCMA]{}'.format(b_leg)
+            b_leg_vars.append("absolute_codec_string=PCMU,PCMA")
+        b_leg = '[{}]{}'.format(','.join(b_leg_vars), b_leg)
 
         cmd = '{{{}}}{} &bridge({})'.format(
             ','.join(variables), a_leg, b_leg)
@@ -361,7 +385,13 @@ class Call(models.Model):
                 if orphan.call and channel.call and orphan.call != channel.call:
                     old_call = orphan.call
                     orphan.call = channel.call
-                    if not old_call.channels:
+                    # Use a fresh DB count instead of `old_call.channels`
+                    # because the One2many cache is not invalidated by
+                    # the inverse-side write above and still reports the
+                    # moved channel as belonging to old_call.
+                    remaining = self.env['connect.channel'].sudo().search_count(
+                        [('call', '=', old_call.id)])
+                    if not remaining:
                         old_call.unlink()
                 debug(self, 'Linked orphan channel %s to parent %s' % (
                     orphan.id, channel.id))

--- a/connect_freeswitch/models/outgoing_route.py
+++ b/connect_freeswitch/models/outgoing_route.py
@@ -33,6 +33,23 @@ class FreeSwitchOutgoingRoute(models.Model):
         destination = params.get('Caller-Destination-Number', '')
         routes = self.sudo().search([('active', '=', True)])
 
+        # Resolve the calling user's configured outgoing CallerID so the
+        # called party sees the right number on PSTN. The directory entry
+        # sets effective_caller_id_* to the extension; we override it here
+        # only for the outbound leg so internal calls still show the
+        # extension.
+        cid_name = ''
+        cid_num = ''
+        connect_user_id = params.get('variable_odoo_connect_user_id')
+        if connect_user_id:
+            try:
+                user = self.env['connect.user'].sudo().browse(int(connect_user_id))
+            except ValueError:
+                user = self.env['connect.user']
+            if user.exists() and user.outgoing_callerid:
+                cid_num = user.outgoing_callerid.number or ''
+                cid_name = user.outgoing_callerid.friendly_name or cid_num
+
         for route in routes:
             if not re.match(route.pattern, destination):
                 continue
@@ -45,6 +62,8 @@ class FreeSwitchOutgoingRoute(models.Model):
                 'route_id': route.id,
                 'pattern': route.pattern,
                 'bridge_data': bridge_data,
+                'cid_name': cid_name,
+                'cid_num': cid_num,
             })
 
         return ''

--- a/connect_twilio/__manifest__.py
+++ b/connect_twilio/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect Twilio',
-    'version': '18.0.1.1.2',
+    'version': '18.0.1.1.3',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'Twilio integration for Oduist Connect',

--- a/connect_twilio/views/user_views.xml
+++ b/connect_twilio/views/user_views.xml
@@ -30,11 +30,6 @@
                 <field name="username"/>
             </xpath>
 
-            <!-- Twilio adds the `status` field on connect.outgoing_callerid; -->
-            <!-- restrict picker to validated CallerIDs or DID numbers. -->
-            <xpath expr="//field[@name='outgoing_callerid']" position="attributes">
-                <attribute name="domain">['|', ('status', '=', 'validated'), ('callerid_type', '=', 'number')]</attribute>
-            </xpath>
             <xpath expr="//field[@name='active']" position="after">
                 <field name="domain"/>
                 <field name="twilio_edge"

--- a/specs/connect_core.md
+++ b/specs/connect_core.md
@@ -313,7 +313,7 @@ Order: `name`
 | `record_calls` | Boolean | Default: True |
 | `voicemail_enabled` | Boolean | |
 | `voicemail_prompt` | Text | Jinja2 template |
-| `outgoing_callerid` | Many2one | `connect.outgoing_callerid`, domain `[('callerid_type', '=', 'number')]` (provider modules may further restrict via view-inheritance, e.g. Twilio adds the `status='validated'` filter) |
+| `outgoing_callerid` | Many2one | `connect.outgoing_callerid`, no domain (provider modules may restrict the picker via view-inheritance) |
 | `missed_calls_notify` | Boolean | |
 | `greeting_message` | Char | |
 | `summary_prompt` | Char | Per-user override |

--- a/specs/connect_twilio.md
+++ b/specs/connect_twilio.md
@@ -487,7 +487,7 @@ Default WhatsApp content template: `voice_call_request` - used for voice call co
 | File | Inherits | Changes |
 |------|----------|---------|
 | `views/settings_views.xml` | `connect.connect_settings_form` | Add Twilio balance group, API keys page, development page, fetch_call_prices |
-| `views/user_views.xml` | `connect.view_connect_user_form`, `connect.view_connect_user_tree` | Add SIP/Client phone tab, domain, edge, whatsapp_sender, application; list adds sip_enabled/client_enabled columns; override `outgoing_callerid` domain to require `status='validated'` (Twilio-only field) |
+| `views/user_views.xml` | `connect.view_connect_user_form`, `connect.view_connect_user_tree` | Add SIP/Client phone tab, domain, edge, whatsapp_sender, application; list adds sip_enabled/client_enabled columns |
 | `views/number_views.xml` | `connect.view_connect_number_form`, `connect.view_connect_number_tree` | Add twiml routing option and twiml column |
 | `views/outgoing_callerid_views.xml` | `connect.view_connect_outgoing_callerid_form` | Add Validate button and validation_code field |
 

--- a/specs/decisions/020-outgoing-callerid-drop-core-domain.md
+++ b/specs/decisions/020-outgoing-callerid-drop-core-domain.md
@@ -1,0 +1,73 @@
+# ADR-020: Drop the `callerid_type='number'` domain from `connect.user.outgoing_callerid`
+
+## Status
+Accepted
+
+## Context
+
+ADR-019 fixed the immediate crash on FreeSWITCH-only deployments by
+removing the Twilio-only `status='validated'` leaf from the core domain.
+The remaining domain was:
+
+```python
+# connect/models/user.py (post-019)
+outgoing_callerid = fields.Many2one(
+    'connect.outgoing_callerid', ondelete='set null',
+    domain=[('callerid_type', '=', 'number')])
+```
+
+`callerid_type` itself is a core selection with two values:
+`outgoing_callerid` ("CallerID") and `number` ("DID Number"). Restricting
+the user form picker to `number` was a leftover from the original
+Twilio-shaped domain: in Twilio, unverified CallerIDs cannot be used as
+outgoing identity, so the picker hid them and exposed DID numbers
+unconditionally. That filter does not belong in the provider-agnostic
+core — for FreeSWITCH (and any other backend that does not differentiate
+between CallerID and DID Number), a user must be able to pick *any*
+`connect.outgoing_callerid` record.
+
+## Decision
+
+Drop the domain attribute entirely from the core field:
+
+```python
+outgoing_callerid = fields.Many2one(
+    'connect.outgoing_callerid', ondelete='set null')
+```
+
+The Twilio view override introduced in ADR-019 stays as-is and continues
+to filter the picker in Twilio installations:
+
+```xml
+<xpath expr="//field[@name='outgoing_callerid']" position="attributes">
+    <attribute name="domain">
+        ['|', ('status', '=', 'validated'),
+              ('callerid_type', '=', 'number')]
+    </attribute>
+</xpath>
+```
+
+## Alternatives considered
+
+- **Keep the `callerid_type='number'` filter in core.** Rejected — it
+  has no provider-agnostic justification and was actively blocking
+  FreeSWITCH users from selecting non-DID caller IDs they had defined.
+- **Move the filter into FreeSWITCH via view-inheritance.** Rejected —
+  FreeSWITCH has no reason to hide CallerID-type records; doing so would
+  just reintroduce the same problem under a different module name.
+
+## Cross-branch backport
+
+Per `CLAUDE.md` versioning rules, the same change must be ported to the
+`18.0` branch with aligned tail version (`18.0.3.1.4` for `connect`).
+The backport ships as a separate PR.
+
+## Consequences
+
+- FreeSWITCH (and any provider-agnostic deployment) can now assign any
+  `connect.outgoing_callerid` record to a user, regardless of
+  `callerid_type`.
+- Twilio installations are unaffected — the Twilio user-form view still
+  restricts the picker to validated CallerIDs or DID numbers.
+- Core remains free of provider-specific filtering, in line with the
+  architecture rule that drove ADR-019.

--- a/specs/decisions/021-freeswitch-outgoing-callerid-dialplan-override.md
+++ b/specs/decisions/021-freeswitch-outgoing-callerid-dialplan-override.md
@@ -1,0 +1,73 @@
+# ADR-021: Apply `connect.user.outgoing_callerid` on the outgoing-route dialplan
+
+## Status
+Accepted
+
+## Context
+
+A SIP/Verto user registered with FreeSWITCH gets `effective_caller_id_*`
+seeded from their `connect.user.exten_number` via the directory template
+(`connect_freeswitch/controllers/freeswitch_xml.py` → directory user
+XML). When the user then dials an external number, the existing
+`dialplan_outgoing_route` template just bridged the call through the
+gateway:
+
+```xml
+<extension name="outgoing_{{ route_id }}">
+  <condition field="destination_number" expression="{{ pattern }}">
+    <action application="set" data="odoo_call_direction=outgoing"/>
+    <action application="export" data="nolocal:absolute_codec_string=PCMU,PCMA"/>
+    <action application="bridge" data="{{ bridge_data }}"/>
+  </condition>
+</extension>
+```
+
+There was no caller-ID rewrite on the B-leg, so the PSTN side saw the
+extension number ("101") instead of the user's configured
+`connect.user.outgoing_callerid` — which is precisely the field whose
+purpose is to control what the called party sees. The substitution
+never happened.
+
+## Decision
+
+Push the user's `outgoing_callerid.number` (and `friendly_name`) into
+the dialplan template via `connect.freeswitch.outgoing_route.generate_dialplan`:
+
+1. `generate_dialplan(params)` reads the calling user from the channel
+   variable `variable_odoo_connect_user_id` (which the directory
+   template already exports).
+2. If that user has an `outgoing_callerid` configured, the route passes
+   `cid_name` / `cid_num` into the template.
+3. The template emits two extra actions before `bridge` only when
+   `cid_num` is set:
+
+   ```xml
+   {% if cid_num %}
+   <action application="set" data="effective_caller_id_number={{ cid_num }}"/>
+   <action application="set" data="effective_caller_id_name={{ cid_name }}"/>
+   {% endif %}
+   ```
+
+This overrides the caller-ID **only for the outbound leg through the
+gateway**. Internal extension-to-extension calls continue to use the
+directory's `effective_caller_id_*` (= extension number), so callees
+still see "101" when their colleague rings them.
+
+## Alternatives considered
+
+- **Push `outgoing_callerid` into `outbound_caller_id_*` in the directory
+  template.** Rejected — `outbound_caller_id_*` is documented as the
+  default outbound caller-ID, but its propagation through Sofia gateways
+  depends on `caller-id-in-from` and other profile settings, so the fix
+  would be silently gateway-specific. Setting `effective_caller_id_*` in
+  the dialplan immediately before `bridge` is explicit and works
+  regardless of gateway configuration.
+- **Override caller-ID in `freeswitch_xml.py` directory render.**
+  Rejected — directory-level override would also leak the PSTN
+  caller-ID into internal calls.
+
+## Cross-branch backport
+
+Per `CLAUDE.md` versioning rules, the same fix ports to the `18.0`
+branch with the aligned tail version (`18.0.1.9.3` for
+`connect_freeswitch`). The backport ships as a separate PR.


### PR DESCRIPTION
Backport of #99 onto the 18.0 branch.

## Summary
- FreeSWITCH `outgoing_callerid` now reaches PSTN on both UA-originated calls (via the outgoing-route dialplan, ADR-021) and click-to-call originates (via a custom A-leg variable + B-leg [vars] override).
- Core `connect.user.outgoing_callerid` picker drops the `callerid_type='number'` domain (ADR-020) and the Twilio view's validated-only override; `_rec_names_search = ['number', 'friendly_name']` fixes the m2o autocomplete crash on the non-stored `name`.
- `mod_xml_cdr` set to `log-b-leg=false` so only the A-leg CDR arrives, killing a race that duplicated `connect.call` records under REPEATABLE READ; parser reads `direction` from `<channel_data>`, URL-decodes variable values, and prefers `effective_caller_id_number` / `odoo_caller_id_number` / `odoo_destination_number` for the recorded caller and called.
- Misc: workers raised to 3 in `.oduflow/odoo.conf`; CLAUDE.md gains the one-bump-per-session rule.

Manifest tail versions aligned with 19.0:
- `connect`: 18.0.3.1.3 → **18.0.3.1.4**
- `connect_twilio`: 18.0.1.1.2 → **18.0.1.1.3**
- `connect_freeswitch`: 18.0.1.9.1 → **18.0.1.9.3**

## Test plan
- [ ] FreeSWITCH UA call to PSTN: single `connect.call`, `call.caller=outgoing_callerid`, `call.called=PSTN number`.
- [ ] FreeSWITCH UA call to internal extension: single `connect.call`, `call.caller=<extension>`.
- [ ] Click-to-call to PSTN: PSTN sees outgoing_callerid; `call.caller=outgoing_callerid`, `call.called=dialled number`.
- [ ] Click-to-call to internal extension: callee sees the originator's extension.
- [ ] Connect user form: outgoing CallerID picker shows all records regardless of `callerid_type`; typing in the picker no longer triggers the SQL error.