### PR TITLE
Fix for #50

### DIFF
--- a/.claude/skills/oduflow-log-usecase/SKILL.md
+++ b/.claude/skills/oduflow-log-usecase/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oduflow-log-usecase
-description: "Log an Oduflow MCP session into the repo's `.oduflow/use-cases/` directory for future reference and statistics. Use this skill when the user asks to record/log/save an Oduflow interaction — phrases like «запиши oduflow», «залогируй oduflow use-case», «сохрани вызов oduflow», «log oduflow», «record oduflow usage». Accepts a slug argument (e.g. `fix-shipment-search`) and creates/updates `YYYY-MM-DD-<slug>.md` with the full task description, every Oduflow MCP call (tool name, arguments, result) and final outcome. Used to build a corpus of real Oduflow usage in this repo."
+description: "Log an Oduflow MCP session into the repo's `.oduflow/use-cases/` directory for future reference and statistics. Use this skill when the user asks to record/log/save an Oduflow interaction — phrases like \"record this oduflow\", \"log oduflow use-case\", \"save oduflow call\", \"record oduflow usage\". Accepts a slug argument (e.g. `fix-shipment-search`) and creates/updates `YYYY-MM-DD-<slug>.md` with the full task description, every Oduflow MCP call (tool name, arguments, result) and final outcome. Used to build a corpus of real Oduflow usage in this repo."
 ---
 
 # oduflow-log-usecase — Oduflow MCP usage log in the repository
@@ -13,12 +13,11 @@ This is NOT a replacement for `.memory/` (task context). This is specifically a 
 
 The user explicitly asks to record oduflow call(s). Typical phrases:
 
-- «запиши этот oduflow»
-- «залогируй oduflow use-case»
-- «сохрани вызов oduflow»
-- «log oduflow»
-- «record oduflow usage»
-- «добавь в .oduflow»
+- "record this oduflow"
+- "log oduflow use-case"
+- "save oduflow call"
+- "record oduflow usage"
+- "add to .oduflow"
 
 Do not run automatically after every MCP call. Only on explicit user request.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,10 @@ Specifically:
 
 ## Conventions
 
+- **Always write comments in English.** This applies to all source and
+  config files (Python, JS, XML, YAML, Dockerfiles, etc.). Do not leave
+  comments in Russian or any other language; translate existing
+  non-English comments to English when you touch the surrounding code.
 - Models follow `connect.<name>` naming (e.g., `connect.call`, `connect.recording`)
 - Protected settings fields (API keys, tokens) are masked with `****` for non-managers
 - Debug logging uses `connect.debug` model with daily cron cleanup

--- a/connect_freeswitch/deploy/freeswitch/conf/autoload_configs/modules.conf.xml
+++ b/connect_freeswitch/deploy/freeswitch/conf/autoload_configs/modules.conf.xml
@@ -3,7 +3,7 @@
     <!-- Loggers (stdout via mod_logfile → /dev/stdout) -->
     <load module="mod_logfile"/>
 
-    <!-- XML Interfaces - для получения конфига из Odoo -->
+    <!-- XML Interfaces - to fetch config from Odoo -->
     <load module="mod_xml_curl"/>
     <load module="mod_xml_cdr"/>
     <load module="mod_xml_rpc"/>

--- a/connect_freeswitch/deploy/freeswitch/conf/dialplan/default.xml
+++ b/connect_freeswitch/deploy/freeswitch/conf/dialplan/default.xml
@@ -1,7 +1,7 @@
 <include>
   <context name="default">
     
-    <!-- Локальные звонки между пользователями -->
+    <!-- Local calls between users -->
     <extension name="local_extension">
       <condition field="destination_number" expression="^(\d+)$">
         <action application="set" data="call_timeout=30"/>
@@ -29,7 +29,7 @@
 
   </context>
   
-  <!-- Public context для входящих неавторизованных -->
+  <!-- Public context for unauthenticated inbound calls -->
   <context name="public">
     <extension name="unloop">
       <condition field="destination_number" expression="^(.*)$">

--- a/connect_freeswitch/deploy/freeswitch/conf/directory/default.xml
+++ b/connect_freeswitch/deploy/freeswitch/conf/directory/default.xml
@@ -1,7 +1,7 @@
 <include>
   <domain name="$${domain}">
     <params>
-      <!-- dial-string для SIP и Verto -->
+      <!-- dial-string for SIP and Verto -->
       <param name="dial-string" value="{^^:sip_invite_domain=${dialed_domain}:presence_id=${dialed_user}@${dialed_domain}}${sofia_contact(*/${dialed_user}@${dialed_domain})},${verto_contact(${dialed_user}@${dialed_domain})}"/>
       <param name="jsonrpc-allowed-methods" value="verto"/>
     </params>
@@ -11,8 +11,8 @@
     <groups>
       <group name="default">
         <users>
-          <!-- Пользователи будут загружаться из Odoo через xml_curl -->
-          <!-- Пример статического пользователя для тестирования: -->
+          <!-- Users are loaded from Odoo via xml_curl -->
+          <!-- Example of a static user for testing: -->
           <!--
           <user id="1000">
             <params>


### PR DESCRIPTION
## Summary

Cleans up Russian-language artefacts in the codebase (closes #50).

Grepped the whole repo for Cyrillic (`[А-Яа-яЁё]`). No Russian was found in Python source (`_logger.*` / inline comments are already English on this branch) — the only real comments/triggers in Russian were:

- **FreeSWITCH config comments** (`connect_freeswitch/deploy/freeswitch/conf/`): translated the XML comments in `dialplan/default.xml`, `directory/default.xml` and `autoload_configs/modules.conf.xml` to English.
- **Skill triggers** (`.claude/skills/oduflow-log-usecase/SKILL.md`): translated the Russian trigger phrases in both the `description` frontmatter and the "When to trigger" list to English, and removed duplicates.

Also added a convention to `CLAUDE.md`: **always write comments in English** (all source/config files), and translate non-English comments when touching the surrounding code.

## Not changed

The only remaining Cyrillic is **example TTS data**, not comments — kept intentionally since it demonstrates the Russian Piper voice:
- `docs/admin/freeswitch-setup.md` — `piper|ru-RU|Здравствуйте…`
- `specs/decisions/004-mod-piper-tts.md` — `piper|ru|Здравствуйте…`

The CI check suggested in the issue ("fail on Cyrillic literals") is out of scope here and can be a follow-up.

## Notes

The deploy-folder changes are **comment-only** — no FreeSWITCH behavior change — so no Docker image rebuild/push is warranted per the deploy versioning policy.