### PR TITLE
feat(freeswitch): auto-generate endpoint auth_password as a passphrase (#81)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,15 @@ Twilio: _inherit = 'connect.foo'  → implements abstract methods, adds provider
 
 **Security groups:** `connect.group_user` (read), `connect.group_admin` (full CRUD), `connect.group_webhook` (webhook record creation)
 
+> **New models — confirm Connect User access first.** When you add a new model,
+> do **not** assume the `connect.group_user` access level. Stop and ask the user
+> what access (none / read / read+write / own-records-only via a record rule)
+> the **Connect User** group should have on it, then write the `ir.model.access`
+> rows (and any `ir.rule`) accordingly. `connect.group_admin` defaults to full
+> CRUD. Admin-only infrastructure/config models (e.g. `connect.settings`,
+> `connect.debug`, `connect.message_configuration`, the firewall models) must
+> grant the user group **no** access.
+
 ## Key Files
 
 - `specs/architecture.md` — Authoritative design specification (boundaries, extension pattern, data flow)

--- a/connect/__manifest__.py
+++ b/connect/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect',
-    'version': '19.0.3.1.4',
+    'version': '19.0.3.1.5',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'Communication platform for Odoo',

--- a/connect/models/settings.py
+++ b/connect/models/settings.py
@@ -205,11 +205,25 @@ class Settings(models.Model):
 
     @api.model
     def get_param(self, param, default=False):
-        data = self.search([])
+        # Sudo-find the singleton so config reads do not require the caller to
+        # hold connect.settings model access (the model is admin-only). Secret
+        # parameters stay protected: a field carrying a ``groups=`` restriction
+        # is only returned to a member of those groups (or to a sudo/internal
+        # caller), never to a plain user reaching get_param over RPC.
+        data = self.sudo().search([])
         if not data:
             data = self.sudo().with_context(no_constrains=True).create({})
         else:
             data = data[0]
+        field = self._fields.get(param)
+        if field is not None and field.groups and not self.env.su:
+            allowed = any(
+                self.env.user.has_group(group.strip())
+                for group in field.groups.split(',')
+                if group.strip() and not group.strip().startswith('!')
+            )
+            if not allowed:
+                return default
         return getattr(data, param, default)
 
     @api.model

--- a/connect/security/access_rules.xml
+++ b/connect/security/access_rules.xml
@@ -167,17 +167,8 @@
         <field name="perm_unlink" eval="True"/>
     </record>
 
-    <!-- connect.settings access -->
-    <record id="access_connect_settings_user" model="ir.model.access">
-        <field name="name">connect.settings user</field>
-        <field name="model_id" ref="model_connect_settings"/>
-        <field name="group_id" ref="group_user"/>
-        <field name="perm_read" eval="True"/>
-        <field name="perm_write" eval="False"/>
-        <field name="perm_create" eval="False"/>
-        <field name="perm_unlink" eval="False"/>
-    </record>
-
+    <!-- connect.settings access (admin-only; non-managers reach non-secret
+         config only through the sudo-safe get_param method) -->
     <record id="access_connect_settings_admin" model="ir.model.access">
         <field name="name">connect.settings admin</field>
         <field name="model_id" ref="model_connect_settings"/>
@@ -335,17 +326,7 @@
         <field name="perm_unlink" eval="True"/>
     </record>
 
-    <!-- connect.debug access -->
-    <record id="access_debug_user" model="ir.model.access">
-        <field name="name">connect.debug user</field>
-        <field name="model_id" ref="model_connect_debug"/>
-        <field name="group_id" ref="group_user"/>
-        <field name="perm_read" eval="True"/>
-        <field name="perm_write" eval="False"/>
-        <field name="perm_create" eval="False"/>
-        <field name="perm_unlink" eval="False"/>
-    </record>
-
+    <!-- connect.debug access (admin-only; the debug() helper writes via sudo) -->
     <record id="access_debug_admin" model="ir.model.access">
         <field name="name">connect.debug admin</field>
         <field name="model_id" ref="model_connect_debug"/>
@@ -366,17 +347,7 @@
         <field name="perm_unlink" eval="False"/>
     </record>
 
-    <!-- connect.message_configuration access -->
-    <record id="access_message_configuration_user" model="ir.model.access">
-        <field name="name">connect.message_configuration user</field>
-        <field name="model_id" ref="model_connect_message_configuration"/>
-        <field name="group_id" ref="group_user"/>
-        <field name="perm_read" eval="True"/>
-        <field name="perm_write" eval="False"/>
-        <field name="perm_create" eval="False"/>
-        <field name="perm_unlink" eval="False"/>
-    </record>
-
+    <!-- connect.message_configuration access (admin-only) -->
     <record id="access_message_configuration_admin" model="ir.model.access">
         <field name="name">connect.message_configuration admin</field>
         <field name="model_id" ref="model_connect_message_configuration"/>

--- a/connect/security/access_rules.xml
+++ b/connect/security/access_rules.xml
@@ -152,7 +152,7 @@
         <field name="model_id" ref="model_connect_endpoint"/>
         <field name="group_id" ref="group_user"/>
         <field name="perm_read" eval="True"/>
-        <field name="perm_write" eval="False"/>
+        <field name="perm_write" eval="True"/>
         <field name="perm_create" eval="False"/>
         <field name="perm_unlink" eval="False"/>
     </record>

--- a/connect/security/record_rules.xml
+++ b/connect/security/record_rules.xml
@@ -20,6 +20,21 @@
         <field name="groups" eval="[(4, ref('group_admin'))]"/>
     </record>
 
+    <!-- connect.endpoint record rules -->
+    <record id="rule_connect_endpoint_user" model="ir.rule">
+        <field name="name">Connect Endpoint: user sees own endpoints</field>
+        <field name="model_id" ref="model_connect_endpoint"/>
+        <field name="domain_force">[('connect_user_id.user', '=', user.id)]</field>
+        <field name="groups" eval="[(4, ref('group_user'))]"/>
+    </record>
+
+    <record id="rule_connect_endpoint_admin" model="ir.rule">
+        <field name="name">Connect Endpoint: admin sees all</field>
+        <field name="model_id" ref="model_connect_endpoint"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('group_admin'))]"/>
+    </record>
+
     <!-- connect.call record rules -->
     <record id="rule_connect_call_user" model="ir.rule">
         <field name="name">Connect Call: user sees own calls</field>

--- a/connect_freeswitch/__init__.py
+++ b/connect_freeswitch/__init__.py
@@ -9,6 +9,20 @@ from odoo import fields
 _logger = logging.getLogger(__name__)
 
 
+def backfill_endpoint_passwords(env):
+    """Generate a passphrase for any endpoint missing an auth_password.
+
+    Non-destructive: endpoints with a password already set are left untouched.
+    Shared helper called from the per-series post-migration entry point.
+    """
+    from .models.passphrase import generate_passphrase
+    endpoints = env['connect.endpoint'].sudo().with_context(active_test=False).search([
+        '|', ('auth_password', '=', False), ('auth_password', '=', ''),
+    ])
+    for endpoint in endpoints:
+        endpoint.auth_password = generate_passphrase()
+
+
 def setup_firewall(env):
     """Idempotent firewall bootstrap — called from post_init_hook and
     per-version post-migration scripts. Generates the shared service

--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.9.3',
+    'version': '19.0.1.10.0',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',
@@ -34,6 +34,7 @@
             'connect_freeswitch/static/src/xml/phone_systray.xml',
             'connect_freeswitch/static/src/xml/parking_panel.xml',
             'connect_freeswitch/static/src/widgets/phone_field/*',
+            'connect_freeswitch/static/src/widgets/endpoint_password/*',
         ],
     },
     'post_init_hook': 'post_init_hook',

--- a/connect_freeswitch/migrations/19.0.1.10.0/post-migrate.py
+++ b/connect_freeswitch/migrations/19.0.1.10.0/post-migrate.py
@@ -1,0 +1,24 @@
+"""Backfill auth_password for endpoints created before passphrase generation.
+
+In 19.0.1.10.0 ``connect.endpoint.auth_password`` became an auto-generated,
+read-only passphrase. Endpoints that predate this change may have an empty
+password. This migration fills only those; endpoints with a password already
+set (including weak manual ones) are left untouched, per the non-destructive
+requirement.
+
+Idempotent: re-running it finds no empty passwords on the second pass.
+"""
+import logging
+
+from odoo import api, SUPERUSER_ID
+
+from odoo.addons.connect_freeswitch import backfill_endpoint_passwords
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    backfill_endpoint_passwords(env)

--- a/connect_freeswitch/models/endpoint.py
+++ b/connect_freeswitch/models/endpoint.py
@@ -2,6 +2,8 @@ import re
 from odoo import fields, models, api
 from odoo.exceptions import ValidationError
 
+from .passphrase import generate_passphrase
+
 
 AUTO_ANSWER_HEADERS = [
     ('Alert-Info:answer-after=0', 'Alert-Info:answer-after=0'),
@@ -22,7 +24,13 @@ class ConnectEndpoint(models.Model):
     _inherit = 'connect.endpoint'
 
     auth_user = fields.Char(string='Auth User')
-    auth_password = fields.Char(string='Auth Password')
+    auth_password = fields.Char(
+        string='Auth Password',
+        readonly=True, copy=False,
+        default=lambda self: generate_passphrase(),
+        help='SIP credential. Auto-generated as a typeable passphrase '
+             '(five word+digit groups). Read-only and auto-managed — use the '
+             'Regenerate button to issue a new one.')
     originate_ring = fields.Boolean(string='Originate Ring', default=True,
         help='Include this endpoint when originating click-to-call calls.')
     auto_answer_header = fields.Selection(
@@ -46,6 +54,12 @@ class ConnectEndpoint(models.Model):
             'recording_url': '',
             'fs_domain': fs_domain,
         })
+
+    def action_regenerate_auth_password(self):
+        """Issue a fresh auto-generated passphrase for the SIP credential."""
+        for record in self:
+            record.auth_password = generate_passphrase()
+        return True
 
     @api.constrains('auth_user')
     def _check_auth_user(self):

--- a/connect_freeswitch/models/passphrase.py
+++ b/connect_freeswitch/models/passphrase.py
@@ -1,0 +1,68 @@
+"""Human-readable passphrase generator for SIP endpoint credentials.
+
+Format: five lowercase words, each followed by a single digit, joined by
+hyphens, e.g. ``flour3-tower9-rome1-watching2-hello8``. The combination of a
+curated wordlist (~240 words) and per-word digits yields high entropy
+(~54 bits for the default five words) while staying easy to read aloud and
+type into a softphone or SIP desk phone keypad.
+
+The generator uses :mod:`secrets` (CSPRNG), never :mod:`random`, because the
+output is a security credential.
+"""
+import secrets
+
+# Short, neutral, easy-to-spell English words (3-7 letters). Curated to avoid
+# ambiguous look-alikes and anything offensive. Order is irrelevant.
+WORDS = [
+    # animals
+    'ant', 'bat', 'bear', 'bee', 'bird', 'bison', 'bull', 'calf', 'camel',
+    'cat', 'clam', 'cobra', 'colt', 'cow', 'crab', 'crane', 'crow', 'deer',
+    'dog', 'dove', 'duck', 'eagle', 'eel', 'elk', 'emu', 'fawn', 'finch',
+    'fish', 'fox', 'frog', 'gecko', 'goat', 'goose', 'hare', 'hawk', 'hen',
+    'heron', 'horse', 'ibis', 'jay', 'koala', 'lamb', 'lark', 'lion', 'llama',
+    'lynx', 'mole', 'moose', 'moth', 'mouse', 'mule', 'newt', 'owl', 'panda',
+    'pig', 'pony', 'puma', 'quail', 'rabbit', 'ram', 'rat', 'raven', 'robin',
+    'seal', 'shark', 'sheep', 'skunk', 'sloth', 'snail', 'snake', 'sparrow',
+    'squid', 'stork', 'swan', 'tiger', 'toad', 'trout', 'tuna', 'turkey',
+    'viper', 'wasp', 'whale', 'wolf', 'wren', 'yak', 'zebra',
+    # nature
+    'bay', 'beach', 'bloom', 'breeze', 'brook', 'cave', 'cliff', 'cloud',
+    'coast', 'coral', 'creek', 'dawn', 'delta', 'dune', 'dusk', 'earth',
+    'fern', 'field', 'flame', 'flower', 'forest', 'frost', 'glade', 'grove',
+    'hill', 'isle', 'lake', 'leaf', 'marsh', 'meadow', 'mist', 'moon', 'moss',
+    'ocean', 'peak', 'petal', 'pine', 'plain', 'pond', 'rain', 'reef', 'ridge',
+    'river', 'rock', 'root', 'sand', 'snow', 'star', 'stone', 'storm',
+    'stream', 'sun', 'thorn', 'tide', 'tree', 'valley', 'vine', 'wave', 'wind',
+    'wood',
+    # food
+    'apple', 'bacon', 'bagel', 'bean', 'berry', 'bread', 'broth', 'butter',
+    'cake', 'candy', 'carrot', 'cherry', 'chili', 'cocoa', 'corn', 'cream',
+    'crust', 'curry', 'dough', 'fig', 'flour', 'grain', 'grape', 'gravy',
+    'herb', 'honey', 'jam', 'kale', 'lemon', 'lime', 'mango', 'maple', 'melon',
+    'milk', 'mint', 'oat', 'olive', 'onion', 'orange', 'peach', 'pear',
+    'pecan', 'pepper', 'pie', 'plum', 'rice', 'sauce', 'soup', 'spice',
+    'sugar', 'syrup', 'taco', 'toast', 'wheat',
+    # objects
+    'anchor', 'arrow', 'badge', 'basket', 'bell', 'boat', 'book', 'bottle',
+    'bowl', 'brick', 'bridge', 'broom', 'brush', 'bucket', 'candle', 'cart',
+    'chain', 'chair', 'clock', 'coin', 'comb', 'cup', 'desk', 'dish', 'door',
+    'drum', 'flag', 'fork', 'frame', 'gate', 'glove', 'hammer', 'hat', 'hook',
+    'jar', 'kettle', 'key', 'knife', 'ladder', 'lamp', 'lantern', 'lock',
+    'map', 'marble', 'mirror', 'nail', 'net', 'oar', 'paddle', 'pencil',
+    'pillow', 'plate', 'pot', 'quilt', 'ribbon', 'ring', 'rope', 'ruler',
+    'saddle', 'sail', 'scarf', 'shell', 'shovel', 'spoon', 'stamp', 'table',
+    'thread', 'ticket', 'torch', 'towel', 'vase', 'wagon', 'wheel', 'whistle',
+]
+
+DIGITS = '0123456789'
+
+
+def generate_passphrase(word_count=5):
+    """Return a passphrase of ``word_count`` ``word+digit`` groups joined by '-'.
+
+    Example: ``flour3-tower9-rome1-watching2-hello8``.
+    """
+    return '-'.join(
+        '{}{}'.format(secrets.choice(WORDS), secrets.choice(DIGITS))
+        for _ in range(word_count)
+    )

--- a/connect_freeswitch/security/access_rules.xml
+++ b/connect_freeswitch/security/access_rules.xml
@@ -166,15 +166,6 @@
         <field name="perm_create" eval="True"/>
         <field name="perm_unlink" eval="True"/>
     </record>
-    <record id="access_firewall_whitelist_user" model="ir.model.access">
-        <field name="name">connect.firewall.whitelist user</field>
-        <field name="model_id" ref="model_connect_firewall_whitelist"/>
-        <field name="group_id" ref="connect.group_user"/>
-        <field name="perm_read" eval="True"/>
-        <field name="perm_write" eval="False"/>
-        <field name="perm_create" eval="False"/>
-        <field name="perm_unlink" eval="False"/>
-    </record>
 
     <!-- connect.firewall.blacklist access rules -->
     <record id="access_firewall_blacklist_admin" model="ir.model.access">
@@ -185,15 +176,6 @@
         <field name="perm_write" eval="True"/>
         <field name="perm_create" eval="True"/>
         <field name="perm_unlink" eval="True"/>
-    </record>
-    <record id="access_firewall_blacklist_user" model="ir.model.access">
-        <field name="name">connect.firewall.blacklist user</field>
-        <field name="model_id" ref="model_connect_firewall_blacklist"/>
-        <field name="group_id" ref="connect.group_user"/>
-        <field name="perm_read" eval="True"/>
-        <field name="perm_write" eval="False"/>
-        <field name="perm_create" eval="False"/>
-        <field name="perm_unlink" eval="False"/>
     </record>
 
     <!-- connect.firewall.event access rules -->
@@ -206,15 +188,6 @@
         <field name="perm_create" eval="False"/>
         <field name="perm_unlink" eval="True"/>
     </record>
-    <record id="access_firewall_event_user" model="ir.model.access">
-        <field name="name">connect.firewall.event user</field>
-        <field name="model_id" ref="model_connect_firewall_event"/>
-        <field name="group_id" ref="connect.group_user"/>
-        <field name="perm_read" eval="True"/>
-        <field name="perm_write" eval="False"/>
-        <field name="perm_create" eval="False"/>
-        <field name="perm_unlink" eval="False"/>
-    </record>
 
     <!-- connect.firewall.agent access rules -->
     <record id="access_firewall_agent_admin" model="ir.model.access">
@@ -223,15 +196,6 @@
         <field name="group_id" ref="connect.group_admin"/>
         <field name="perm_read" eval="True"/>
         <field name="perm_write" eval="True"/>
-        <field name="perm_create" eval="False"/>
-        <field name="perm_unlink" eval="False"/>
-    </record>
-    <record id="access_firewall_agent_user" model="ir.model.access">
-        <field name="name">connect.firewall.agent user</field>
-        <field name="model_id" ref="model_connect_firewall_agent"/>
-        <field name="group_id" ref="connect.group_user"/>
-        <field name="perm_read" eval="True"/>
-        <field name="perm_write" eval="False"/>
         <field name="perm_create" eval="False"/>
         <field name="perm_unlink" eval="False"/>
     </record>

--- a/connect_freeswitch/static/src/widgets/endpoint_password/endpoint_password.js
+++ b/connect_freeswitch/static/src/widgets/endpoint_password/endpoint_password.js
@@ -1,0 +1,53 @@
+/** @odoo-module **/
+"use strict"
+
+import {Component, useState} from "@odoo/owl"
+import {registry} from "@web/core/registry"
+import {useService} from "@web/core/utils/hooks"
+import {_t} from "@web/core/l10n/translation"
+import {standardFieldProps} from "@web/views/fields/standard_field_props"
+
+/**
+ * Read-only display for an auto-generated SIP endpoint password.
+ *
+ * The value is masked by default; a Show/Hide toggle reveals it in plaintext
+ * (useful when typing it into a mobile device without copy/paste) and a Copy
+ * button puts it on the clipboard without revealing it.
+ */
+export class EndpointPasswordField extends Component {
+    static template = "connect_freeswitch.EndpointPasswordField"
+    static props = {...standardFieldProps}
+
+    setup() {
+        this.notification = useService("notification")
+        this.state = useState({revealed: false})
+    }
+
+    get value() {
+        return this.props.record.data[this.props.name] || ""
+    }
+
+    toggleReveal() {
+        this.state.revealed = !this.state.revealed
+    }
+
+    async copyToClipboard() {
+        if (!this.value) {
+            return
+        }
+        try {
+            await navigator.clipboard.writeText(this.value)
+            this.notification.add(_t("Password copied to clipboard"), {type: "success"})
+        } catch {
+            this.notification.add(_t("Could not access the clipboard"), {type: "warning"})
+        }
+    }
+}
+
+export const endpointPasswordField = {
+    component: EndpointPasswordField,
+    displayName: _t("Endpoint Password"),
+    supportedTypes: ["char"],
+}
+
+registry.category("fields").add("endpoint_password", endpointPasswordField)

--- a/connect_freeswitch/static/src/widgets/endpoint_password/endpoint_password.scss
+++ b/connect_freeswitch/static/src/widgets/endpoint_password/endpoint_password.scss
@@ -1,0 +1,11 @@
+.o_field_endpoint_password {
+  .o_endpoint_password_input {
+    min-width: 24rem;
+    font-family: var(--bs-font-monospace, monospace);
+  }
+
+  .o_endpoint_password_btn {
+    cursor: pointer;
+    line-height: 1;
+  }
+}

--- a/connect_freeswitch/static/src/widgets/endpoint_password/endpoint_password.xml
+++ b/connect_freeswitch/static/src/widgets/endpoint_password/endpoint_password.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="connect_freeswitch.EndpointPasswordField">
+        <div class="o_field_endpoint_password d-inline-flex align-items-center">
+            <input class="o_input o_endpoint_password_input"
+                   t-att-type="state.revealed ? 'text' : 'password'"
+                   t-att-value="value"
+                   readonly="readonly" autocomplete="off"/>
+            <button type="button"
+                    class="btn btn-link p-0 ms-2 o_endpoint_password_btn"
+                    t-att-title="state.revealed ? 'Hide password' : 'Show password'"
+                    t-att-aria-label="state.revealed ? 'Hide password' : 'Show password'"
+                    t-on-click="toggleReveal">
+                <i t-att-class="state.revealed ? 'fa fa-eye-slash' : 'fa fa-eye'"/>
+            </button>
+            <button type="button"
+                    class="btn btn-link p-0 ms-1 o_endpoint_password_btn"
+                    title="Copy password" aria-label="Copy password"
+                    t-on-click="copyToClipboard">
+                <i class="fa fa-clipboard"/>
+            </button>
+        </div>
+    </t>
+
+</templates>

--- a/connect_freeswitch/views/endpoint_views.xml
+++ b/connect_freeswitch/views/endpoint_views.xml
@@ -33,7 +33,13 @@
             <div class="oe_title" position="after">
                 <group string="Authentication">
                     <field name="auth_user"/>
-                    <field name="auth_password" password="True"/>
+                    <label for="auth_password"/>
+                    <div class="d-flex align-items-center">
+                        <field name="auth_password" widget="endpoint_password" nolabel="1"/>
+                        <button name="action_regenerate_auth_password" type="object"
+                                string="Regenerate" class="btn-link ms-2"
+                                icon="fa-refresh" invisible="not id"/>
+                    </div>
                 </group>
                 <group string="Click-to-Call" invisible="not connect_user_id">
                     <field name="originate_ring" widget="boolean_toggle"/>

--- a/connect_freeswitch/views/firewall_views.xml
+++ b/connect_freeswitch/views/firewall_views.xml
@@ -249,6 +249,7 @@ action = {
     <menuitem id="menu_firewall_root"
               name="Firewall"
               parent="connect.menu_connect_pbx"
+              groups="connect.group_admin"
               sequence="80"/>
 
     <menuitem id="menu_firewall_agent"

--- a/connect_twilio/__manifest__.py
+++ b/connect_twilio/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect Twilio',
-    'version': '19.0.1.1.3',
+    'version': '19.0.1.1.4',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'Twilio integration for Oduist Connect',

--- a/connect_twilio/models/settings.py
+++ b/connect_twilio/models/settings.py
@@ -87,11 +87,8 @@ class Settings(models.Model):
     @api.model
     def get_client(self):
         try:
-            (
-                self.check_access_rule("read")
-                if release.version_info[0] < 18
-                else self.check_access("read")
-            )
+            # connect.settings is admin-only; credentials are read with sudo()
+            # below, so no caller-level model access check is needed here.
             account_sid = self.sudo().get_param("account_sid")
             auth_token = self.sudo().get_param("auth_token")
             client = Client(account_sid, auth_token)

--- a/docs/admin/freeswitch-setup.md
+++ b/docs/admin/freeswitch-setup.md
@@ -114,7 +114,7 @@ Each PBX user needs at least one endpoint to make and receive calls.
 | **Connect User** | The PBX user this endpoint belongs to. |
 | **SIP Domain** | FreeSWITCH server IP or hostname. |
 | **Auth User** | SIP/Verto username (typically the extension number). |
-| **Auth Password** | SIP/Verto password. |
+| **Auth Password** | SIP/Verto password. **Auto-generated** on creation as a typeable passphrase (e.g. `flour3-tower9-rome1-watching2-hello8`) and read-only. Masked by default — use the eye toggle to reveal it for manual entry on a device, the clipboard button to copy it, or **Regenerate** to issue a new one. |
 | **SIP Enabled** | Enable SIP phone registration for this endpoint. |
 | **WebRTC Enabled** | Enable browser-based Verto calling. |
 

--- a/specs/connect_core.md
+++ b/specs/connect_core.md
@@ -740,7 +740,7 @@ All models get access rules for the three groups:
 | `connect.user_callflow_call` | Read | Full | - |
 | `connect.debug` | Read | Full | Create |
 | `connect.settings` | Read | Full | - |
-| `connect.endpoint` | Read | Full | - |
+| `connect.endpoint` | Read+Write | Full | - |
 | `connect.message_configuration` | Read | Full | - |
 | `connect.favorite` | Read+Write | Full | - |
 
@@ -748,10 +748,13 @@ All models get access rules for the three groups:
 
 - Users see only their own `connect.user` records
 - Admins see all `connect.user` records
-- Users see only `connect.endpoint` records linked to their own `connect.user`
-  (`connect_user_id.user = user`); admins see all (`rule_connect_endpoint_user` /
-  `rule_connect_endpoint_admin`). This keeps the FreeSWITCH `auth_password` of one
-  user's SIP device out of other users' reach.
+- Users can read and edit only `connect.endpoint` records linked to their own
+  `connect.user` (`connect_user_id.user = user`); admins see all
+  (`rule_connect_endpoint_user` / `rule_connect_endpoint_admin`). The record rule
+  applies to write as well, so a user can self-manage their own SIP device
+  (Regenerate password, set Originate Ring / auto-answer header) but never touch
+  another user's endpoint — and one user's `auth_password` stays out of another's
+  reach. `group_user` has read+write but not create/unlink on the model.
 - Users see calls/messages/recordings associated with their `connect.user` or where they
   are the `caller_user`/`answered_user`/`sender_user`
 

--- a/specs/connect_core.md
+++ b/specs/connect_core.md
@@ -748,6 +748,10 @@ All models get access rules for the three groups:
 
 - Users see only their own `connect.user` records
 - Admins see all `connect.user` records
+- Users see only `connect.endpoint` records linked to their own `connect.user`
+  (`connect_user_id.user = user`); admins see all (`rule_connect_endpoint_user` /
+  `rule_connect_endpoint_admin`). This keeps the FreeSWITCH `auth_password` of one
+  user's SIP device out of other users' reach.
 - Users see calls/messages/recordings associated with their `connect.user` or where they
   are the `caller_user`/`answered_user`/`sender_user`
 

--- a/specs/connect_core.md
+++ b/specs/connect_core.md
@@ -738,11 +738,21 @@ All models get access rules for the three groups:
 | `connect.callflow_choice` | Read | Full | - |
 | `connect.user_callflow` | Read | Full | - |
 | `connect.user_callflow_call` | Read | Full | - |
-| `connect.debug` | Read | Full | Create |
-| `connect.settings` | Read | Full | - |
+| `connect.debug` | - | Full | Create |
+| `connect.settings` | - | Full | - |
 | `connect.endpoint` | Read+Write | Full | - |
-| `connect.message_configuration` | Read | Full | - |
+| `connect.message_configuration` | - | Full | - |
 | `connect.favorite` | Read+Write | Full | - |
+
+`connect.settings`, `connect.debug` and `connect.message_configuration` are
+**admin-only** — `group_user` has no model access. End-user features still need
+configuration values, so `connect.settings.get_param()` sudo-finds the singleton
+and returns the value without requiring the caller to hold model access; it only
+blocks parameters whose field carries a `groups=` restriction (the secrets, e.g.
+`openai_api_key`, Twilio `auth_token`, `firewall_service_token`) for non-members,
+so a plain user cannot read secrets via `get_param` over RPC. `set_param` stays
+non-sudo (configuration writes remain manager-only). The `debug()` helper writes
+`connect.debug` via sudo, so logging from user-triggered code keeps working.
 
 ### Record Rules
 

--- a/specs/connect_freeswitch.md
+++ b/specs/connect_freeswitch.md
@@ -116,7 +116,7 @@ Beyond firewall, the module contains:
 | Model | Purpose |
 |---|---|
 | `connect.user` (`_inherit`) | adds WebRTC fields and dial-string generation |
-| `connect.endpoint` (`_inherit`) | SIP endpoint management |
+| `connect.endpoint` (`_inherit`) | SIP endpoint management. `auth_password` is auto-generated as a typeable passphrase (`models/passphrase.py`, `secrets`-based), `readonly` + `copy=False`, defaulted on create; `action_regenerate_auth_password()` issues a new one. Empty passwords on existing endpoints are backfilled non-destructively by `backfill_endpoint_passwords(env)` (post-migration). UI uses the `endpoint_password` OWL widget (mask + Show/Hide + Copy) — see ADR-022 |
 | `connect.exten` (`_inherit`) | extension number tooling |
 | `connect.callflow` (`_inherit`) | callflow extension for FreeSWITCH-specific destinations; `_get_piper_language()` returns the BCP-47 code used as the Piper TTS model key (must match a `<model language="...">` entry in `piper_tts.conf.xml`) |
 | `connect.number` (`_inherit`) | DID assignment |

--- a/specs/connect_freeswitch.md
+++ b/specs/connect_freeswitch.md
@@ -146,12 +146,15 @@ twin) is bootstrapped on install / upgrade by `setup_firewall(env)` in
 
 See `security/access_rules.xml`.
 
+Firewall models are **admin-only** — `connect_user` has no access at all (the
+`Firewall` menu is also gated on `connect.group_admin`).
+
 | Model | `connect_admin` | `connect_user` |
 |---|---|---|
-| `connect.firewall.whitelist` | CRUD | read |
-| `connect.firewall.blacklist` | CRUD | read |
-| `connect.firewall.event` | read + unlink | read |
-| `connect.firewall.agent` | read + write | read |
+| `connect.firewall.whitelist` | CRUD | — |
+| `connect.firewall.blacklist` | CRUD | — |
+| `connect.firewall.event` | read + unlink | — |
+| `connect.firewall.agent` | read + write | — |
 
 Whitelist / blacklist edits are admin-only via the Odoo UI; the
 service has no model-level access at all because it goes through the

--- a/specs/decisions/022-endpoint-auth-password-passphrase.md
+++ b/specs/decisions/022-endpoint-auth-password-passphrase.md
@@ -1,0 +1,87 @@
+# ADR-022: Endpoint `auth_password` auto-generated as a typeable passphrase
+
+## Status
+Accepted
+
+## Context
+
+GitHub issue [#81](https://github.com/oduist/connect_addons_ng/issues/81).
+
+`connect.endpoint.auth_password` (added by `connect_freeswitch`,
+`models/endpoint.py`) was a plain free-text `Char` with no generation,
+no validation and no minimum length. A user could save a single
+character as the SIP credential — a real security risk, since this
+password authenticates a device registering to FreeSWITCH.
+
+The credential is special in that operators frequently **type it by
+hand** into a desk phone or a softphone on a mobile device with no
+copy/paste. A random alphanumeric string is secure but painful to enter;
+a passphrase is both.
+
+Prior art in the codebase:
+- `connect_freeswitch/models/fs_user.py` — `webrtc_password`,
+  `readonly=True`, generated with `secrets.token_urlsafe(16)`.
+- `connect_twilio/models/user.py` — `generate_twilio_password()`.
+
+## Decision
+
+1. **Generate a human-readable passphrase.**
+   `connect_freeswitch/models/passphrase.py` ships a curated wordlist
+   (~240 short, neutral words) and `generate_passphrase(word_count=5)`,
+   which returns five `word+digit` groups joined by hyphens, e.g.
+   `flour3-tower9-rome1-watching2-hello8`. It uses `secrets` (CSPRNG),
+   never `random`. Entropy ≈ `5·log2(240) + 5·log2(10) ≈ 56 bits`.
+
+2. **Auto-manage the field.** `auth_password` becomes
+   `readonly=True, copy=False` with
+   `default=lambda self: generate_passphrase()`, so every new endpoint
+   (including inline rows on the user form and duplicated records) gets a
+   fresh strong password the user cannot accidentally weaken.
+   `action_regenerate_auth_password()` is the explicit, server-side way
+   to rotate it.
+
+3. **Reveal/Copy UI.** A small read-only OWL field widget
+   (`static/src/widgets/endpoint_password/`, registered as
+   `endpoint_password`) masks the value by default, adds a Show/Hide eye
+   toggle (for manual entry on devices without paste) and a
+   Copy-to-clipboard button. The inline endpoint list on the user form
+   keeps `password="True"` masking.
+
+4. **Non-destructive backfill.** `backfill_endpoint_passwords(env)` in
+   `connect_freeswitch/__init__.py`, called from
+   `migrations/19.0.1.10.0/post-migrate.py`, fills only endpoints whose
+   `auth_password` is empty. Existing passwords — even weak manual ones —
+   are left untouched, per the issue's acceptance criteria.
+
+## Alternatives considered
+
+- **Random alphanumeric (`secrets.token_urlsafe`) like
+  `webrtc_password`.** Rejected for this field: WebRTC passwords are
+  copy/pasted by the browser client; endpoint passwords are frequently
+  typed by hand into SIP hardware, where a passphrase is far easier.
+- **Keep the field editable, only add a default.** Rejected — the issue
+  requires the value be auto-managed so it cannot be silently weakened.
+- **Odoo's built-in `CopyClipboardChar` widget.** Rejected — it renders
+  the value in plaintext and offers no Show/Hide; it cannot satisfy
+  "masked by default, revealable on demand".
+- **Force-rotate weak existing passwords during migration.** Rejected —
+  the acceptance criteria mandate a non-destructive migration; rotating a
+  password an operator already programmed into a live device would break
+  that device's registration on upgrade.
+
+## Cross-branch backport
+
+Per `CLAUDE.md` versioning rules, port to the `18.0` branch with the
+aligned tail version `18.0.1.10.0`, reusing the same
+`generate_passphrase()` / `backfill_endpoint_passwords()` helpers, with
+the per-series entry point `migrations/18.0.1.10.0/post-migrate.py`.
+Ships as a separate PR after this one merges.
+
+## Consequences
+
+- New endpoints always carry a strong, typeable SIP password.
+- Operators can reveal, copy or regenerate the password from the form.
+- Pre-existing endpoints with empty passwords are healed on upgrade;
+  those with a set password are unchanged.
+- The field is no longer freely editable; rotation goes through
+  **Regenerate**.

--- a/specs/decisions/022-endpoint-auth-password-passphrase.md
+++ b/specs/decisions/022-endpoint-auth-password-passphrase.md
@@ -74,18 +74,23 @@ Prior art in the codebase:
 Storing a strong password is pointless if every user can read it. Two
 row/menu-level fixes ship in the same change:
 
-1. **Endpoints are private to their owner.** `connect.endpoint` had an
-   `ir.model.access` granting `group_user` read but **no record rule**,
-   so any Connect user could list every endpoint — and now every SIP
-   password. Added `rule_connect_endpoint_user`
+1. **Endpoints are private to their owner — and self-manageable.**
+   `connect.endpoint` had an `ir.model.access` granting `group_user` read
+   but **no record rule**, so any Connect user could list every endpoint —
+   and now every SIP password. Added `rule_connect_endpoint_user`
    (`[('connect_user_id.user', '=', user.id)]`) and the paired
    `rule_connect_endpoint_admin` (`[(1, '=', 1)]`) in core
    `connect/security/record_rules.xml`, mirroring the existing
    `connect.user` / `connect.call` rules. Rules live in **core** because
    the model and `connect_user_id` are core; `group_admin` implies
    `group_user`, so the admin rule is required for admins to keep full
-   visibility. The FreeSWITCH directory/dialplan controllers read
-   endpoints via `sudo()`, so XML generation is unaffected.
+   visibility. The record rule covers **write**, and `group_user` is
+   granted `perm_write` (but not create/unlink) on the model, so a user can
+   self-manage their own device — Regenerate the password, toggle Originate
+   Ring, set the auto-answer header — yet can never touch another user's
+   endpoint (a write that would move `connect_user_id` away from the owner
+   is rejected by the rule). The FreeSWITCH directory/dialplan controllers
+   read endpoints via `sudo()`, so XML generation is unaffected.
 
 2. **Firewall is admin-only.** `group_user` previously had read access to
    `connect.firewall.{whitelist,blacklist,event,agent}`. Those four

--- a/specs/decisions/022-endpoint-auth-password-passphrase.md
+++ b/specs/decisions/022-endpoint-auth-password-passphrase.md
@@ -69,11 +69,37 @@ Prior art in the codebase:
   password an operator already programmed into a live device would break
   that device's registration on upgrade.
 
+## Related security hardening
+
+Storing a strong password is pointless if every user can read it. Two
+row/menu-level fixes ship in the same change:
+
+1. **Endpoints are private to their owner.** `connect.endpoint` had an
+   `ir.model.access` granting `group_user` read but **no record rule**,
+   so any Connect user could list every endpoint — and now every SIP
+   password. Added `rule_connect_endpoint_user`
+   (`[('connect_user_id.user', '=', user.id)]`) and the paired
+   `rule_connect_endpoint_admin` (`[(1, '=', 1)]`) in core
+   `connect/security/record_rules.xml`, mirroring the existing
+   `connect.user` / `connect.call` rules. Rules live in **core** because
+   the model and `connect_user_id` are core; `group_admin` implies
+   `group_user`, so the admin rule is required for admins to keep full
+   visibility. The FreeSWITCH directory/dialplan controllers read
+   endpoints via `sudo()`, so XML generation is unaffected.
+
+2. **Firewall is admin-only.** `group_user` previously had read access to
+   `connect.firewall.{whitelist,blacklist,event,agent}`. Those four
+   `*_user` `ir.model.access` records were removed (Odoo drops the stale
+   rows on upgrade) and `menu_firewall_root` is gated on
+   `connect.group_admin`. Firewall is an infrastructure concern with no
+   end-user use case.
+
 ## Cross-branch backport
 
 Per `CLAUDE.md` versioning rules, port to the `18.0` branch with the
-aligned tail version `18.0.1.10.0`, reusing the same
-`generate_passphrase()` / `backfill_endpoint_passwords()` helpers, with
+aligned tail versions `18.0.1.10.0` (`connect_freeswitch`) and
+`18.0.3.1.5` (`connect`), reusing the same `generate_passphrase()` /
+`backfill_endpoint_passwords()` helpers and the same security rules, with
 the per-series entry point `migrations/18.0.1.10.0/post-migrate.py`.
 Ships as a separate PR after this one merges.
 


### PR DESCRIPTION
Closes #81.

**Endpoint passwords.** `connect.endpoint.auth_password` is now auto-generated as a typeable, `secrets`-based passphrase (five word+digit groups, e.g. `flour3-tower9-rome1-watching2-hello8`), made `readonly`/`copy=False`, and surfaced through a new `endpoint_password` OWL widget with masking + Show/Hide toggle + Copy button, plus a Regenerate action; a non-destructive post-migration (`19.0.1.10.0`) backfills only endpoints with an empty password. Bumps `connect_freeswitch` to `19.0.1.10.0` and adds ADR-022 with spec/doc updates.

**Endpoint access.** Adds owner/admin record rules so a Connect user can see and self-manage only their own endpoint (regenerate the password, set Originate Ring / auto-answer header) instead of viewing everyone's — and thus everyone's SIP password; `group_user` gets read+write (no create/unlink) on `connect.endpoint`, scoped to own records by the rule.

**Admin-only models.** Removes `group_user` access to the firewall models (whitelist/blacklist/event/agent, Firewall menu gated on `group_admin`) and to `connect.settings`, `connect.debug`, `connect.message_configuration`. End-user features still read config because `connect.settings.get_param()` is now sudo-safe but refuses `groups=`-restricted secrets (OpenAI key, Twilio auth token, firewall token) to non-managers; the `debug()` helper already writes via sudo, and Twilio `get_client` drops its now-redundant read check. Bumps `connect` to `19.0.3.1.5`, `connect_twilio` to `19.0.1.1.4`, and adds a CLAUDE.md rule to confirm the Connect User access level for new models.

Verified end-to-end on an oduflow environment: passphrase generation, non-destructive migration, readonly/Show-Hide/Copy/Regenerate, per-owner endpoint isolation (own editable, others denied, no create/unlink), firewall denial, the three admin-only models denied to users, non-secret config still readable via `get_param` while secrets stay blocked, the WebRTC phone config path, and `debug()` logging all confirmed.