### PR TITLE
docs(tests): explain gated test suite to users + oduflow test-run note (port of #103)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,6 +262,28 @@ uv pip install "odoo-addon-connect-freeswitch @ git+https://github.com/oduist/co
 
 Replace `@18.0` with `@19.0` for the Odoo 19 series. Tests are not available in this mode.
 
+## Running tests in an oduflow environment
+
+`tests_suite` lives **only on the local workstation**. The oduflow Odoo
+environment has **no access** to the private submodule, and `pull_and_apply`
+will **not** carry the tests across: `pull_and_apply` syncs via `git push`,
+where `tests_suite` is just a gitlink whose contents are never pushed (and
+`.gitmodules` carries `update = none` anyway). So after `pull_and_apply` the
+environment still has an empty `tests/` loader and `run_odoo_tests` finds
+nothing.
+
+To run a specific test in an oduflow environment:
+
+1. Read the test locally from `tests_suite/<addon>/tests/test_<name>.py`.
+2. Copy it into the environment with the **`write_file_in_odoo`** MCP tool,
+   writing to the path the loader scans — `tests_suite/<addon>/tests/test_<name>.py`
+   (relative to the repo root inside the container).
+3. Run `run_odoo_tests <addon>`.
+
+Do **not** rely on `pull_and_apply` to deliver test files — it never will.
+Treat `write_file_in_odoo` as the only channel for getting a `test_*.py`
+into the environment.
+
 ## Self-driven verification of changes
 
 When a change can realistically be checked in the UI, verify it yourself — do not delegate the check to the user.

--- a/connect/tests/README.md
+++ b/connect/tests/README.md
@@ -1,0 +1,43 @@
+# About the test suite
+
+These Odoo modules are published **without their automated test suite** — and
+that is a deliberate choice, not an oversight or a missing piece.
+
+## Why the tests are not here
+
+The test suite is one of our core engineering assets. It encodes years of
+accumulated knowledge about how this product is supposed to behave: the edge
+cases, the regressions we have already paid for once, the provider-specific
+quirks, and the exact contracts each model and controller must honour. Writing
+and maintaining that suite is a large part of what makes the product reliable.
+
+We keep it private on purpose. Our business is building, customising,
+supporting and maintaining this software for the people who use it — and we
+believe we do that better than anyone, because we wrote it and we own the full
+test coverage behind it. When you bring a requirement or a problem to us, the
+result is delivered properly, verified against the full suite, and it becomes
+available to every other user of the product as well. That shared, well-tested
+core is what everyone benefits from.
+
+## You can still run, deploy and use everything
+
+Nothing here is crippled. The modules install cleanly and run in full without
+the test suite — the `tests/` loader is simply a no-op when the private
+`tests_suite` submodule is absent. Use the product freely under its license.
+
+## If you want to modify the product yourself
+
+If you would rather extend or adapt the product on your own — with your own
+developers or your own AI agents — that is fine, but please talk to us first.
+We license the private `tests_suite` separately, as a paid add-on. With it you
+get the same safety net we develop against, so you can change the code with
+confidence and immediately know whether something broke.
+
+The test suite is licensed for **your own internal use only**. Redistribution,
+resale or public re-publication of the test suite — in whole or in part — is
+not permitted.
+
+## Get in touch
+
+Need a feature, an integration, support, or a `tests_suite` license?
+Reach out to us — we are happy to help.

--- a/connect_freeswitch/tests/README.md
+++ b/connect_freeswitch/tests/README.md
@@ -1,0 +1,43 @@
+# About the test suite
+
+These Odoo modules are published **without their automated test suite** — and
+that is a deliberate choice, not an oversight or a missing piece.
+
+## Why the tests are not here
+
+The test suite is one of our core engineering assets. It encodes years of
+accumulated knowledge about how this product is supposed to behave: the edge
+cases, the regressions we have already paid for once, the provider-specific
+quirks, and the exact contracts each model and controller must honour. Writing
+and maintaining that suite is a large part of what makes the product reliable.
+
+We keep it private on purpose. Our business is building, customising,
+supporting and maintaining this software for the people who use it — and we
+believe we do that better than anyone, because we wrote it and we own the full
+test coverage behind it. When you bring a requirement or a problem to us, the
+result is delivered properly, verified against the full suite, and it becomes
+available to every other user of the product as well. That shared, well-tested
+core is what everyone benefits from.
+
+## You can still run, deploy and use everything
+
+Nothing here is crippled. The modules install cleanly and run in full without
+the test suite — the `tests/` loader is simply a no-op when the private
+`tests_suite` submodule is absent. Use the product freely under its license.
+
+## If you want to modify the product yourself
+
+If you would rather extend or adapt the product on your own — with your own
+developers or your own AI agents — that is fine, but please talk to us first.
+We license the private `tests_suite` separately, as a paid add-on. With it you
+get the same safety net we develop against, so you can change the code with
+confidence and immediately know whether something broke.
+
+The test suite is licensed for **your own internal use only**. Redistribution,
+resale or public re-publication of the test suite — in whole or in part — is
+not permitted.
+
+## Get in touch
+
+Need a feature, an integration, support, or a `tests_suite` license?
+Reach out to us — we are happy to help.

--- a/connect_twilio/tests/README.md
+++ b/connect_twilio/tests/README.md
@@ -1,0 +1,43 @@
+# About the test suite
+
+These Odoo modules are published **without their automated test suite** — and
+that is a deliberate choice, not an oversight or a missing piece.
+
+## Why the tests are not here
+
+The test suite is one of our core engineering assets. It encodes years of
+accumulated knowledge about how this product is supposed to behave: the edge
+cases, the regressions we have already paid for once, the provider-specific
+quirks, and the exact contracts each model and controller must honour. Writing
+and maintaining that suite is a large part of what makes the product reliable.
+
+We keep it private on purpose. Our business is building, customising,
+supporting and maintaining this software for the people who use it — and we
+believe we do that better than anyone, because we wrote it and we own the full
+test coverage behind it. When you bring a requirement or a problem to us, the
+result is delivered properly, verified against the full suite, and it becomes
+available to every other user of the product as well. That shared, well-tested
+core is what everyone benefits from.
+
+## You can still run, deploy and use everything
+
+Nothing here is crippled. The modules install cleanly and run in full without
+the test suite — the `tests/` loader is simply a no-op when the private
+`tests_suite` submodule is absent. Use the product freely under its license.
+
+## If you want to modify the product yourself
+
+If you would rather extend or adapt the product on your own — with your own
+developers or your own AI agents — that is fine, but please talk to us first.
+We license the private `tests_suite` separately, as a paid add-on. With it you
+get the same safety net we develop against, so you can change the code with
+confidence and immediately know whether something broke.
+
+The test suite is licensed for **your own internal use only**. Redistribution,
+resale or public re-publication of the test suite — in whole or in part — is
+not permitted.
+
+## Get in touch
+
+Need a feature, an integration, support, or a `tests_suite` license?
+Reach out to us — we are happy to help.


### PR DESCRIPTION
Backport of #103 to the 18.0 series.

Adds a `tests/README.md` to `connect`, `connect_twilio` and `connect_freeswitch` explaining that the modules ship without their private test suite on purpose, inviting users to reach out for support and customisation, and offering the `tests_suite` as a separately licensed, internal-use-only, non-redistributable add-on. The README is inert — Odoo's loader only picks up `test_*.py`, so it never affects installs or test discovery.

Also documents in `CLAUDE.md` that `tests_suite` is local-only and that `pull_and_apply` never delivers test files into an oduflow environment, so `write_file_in_odoo` must be used to copy a `test_*.py` into `tests_suite/<addon>/tests/` before running `run_odoo_tests`. The 18.0 series-prefix lines in `CLAUDE.md` are left untouched.