### PR TITLE
fix(freeswitch): tolerate optional '+' in inbound DID matching (#42)

### DIFF
--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.10.0',
+    'version': '19.0.1.10.1',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',

--- a/connect_freeswitch/controllers/freeswitch_xml.py
+++ b/connect_freeswitch/controllers/freeswitch_xml.py
@@ -350,16 +350,9 @@ class FreeSwitchXMLController(http.Controller):
         """Route inbound calls from PSTN trunks via connect.number."""
         Number = request.env['connect.number'].sudo()
 
-        # Try exact match on phone number
-        number = Number.search([
-            ('phone_number', '=', destination),
-        ], limit=1)
-
-        # Try with + prefix if not found
-        if not number and not destination.startswith('+'):
-            number = Number.search([
-                ('phone_number', '=', '+' + destination),
-            ], limit=1)
+        # Match tolerating an optional leading '+' between the trunk format and
+        # the stored DID (see connect.number._find_by_did).
+        number = Number._find_by_did(destination)
 
         if number:
             return number.generate_dialplan(params)

--- a/connect_freeswitch/data/fs_templates.xml
+++ b/connect_freeswitch/data/fs_templates.xml
@@ -390,12 +390,14 @@ Variables:
         <field name="description">Inbound DID routing from PSTN trunks.
 
 Variables:
-  phone_number    - DID phone number
+  number_regex    - destination_number regex (bare digits, optional leading '+')
+  did_label       - DID digits without '+' (used for the extension name)
+  phone_number    - DID phone number as stored (kept for custom templates)
   number_id       - connect.number record ID
   destination     - Destination type: 'user' or 'callflow'
   transfer_target - Extension/number to transfer to (or empty if no destination)</field>
-        <field name="content"><![CDATA[<extension name="did_{{ phone_number }}">
-  <condition field="destination_number" expression="^{{ phone_number }}$">
+        <field name="content"><![CDATA[<extension name="did_{{ did_label }}">
+  <condition field="destination_number" expression="^{{ number_regex }}$">
     <action application="set" data="odoo_call_direction=inbound"/>
     <action application="set" data="odoo_number_id={{ number_id }}"/>
     {% if transfer_target %}
@@ -405,8 +407,8 @@ Variables:
     {% endif %}
   </condition>
 </extension>]]></field>
-        <field name="default_content"><![CDATA[<extension name="did_{{ phone_number }}">
-  <condition field="destination_number" expression="^{{ phone_number }}$">
+        <field name="default_content"><![CDATA[<extension name="did_{{ did_label }}">
+  <condition field="destination_number" expression="^{{ number_regex }}$">
     <action application="set" data="odoo_call_direction=inbound"/>
     <action application="set" data="odoo_number_id={{ number_id }}"/>
     {% if transfer_target %}

--- a/connect_freeswitch/models/number.py
+++ b/connect_freeswitch/models/number.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from odoo import fields, models
+from odoo import api, fields, models
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +20,21 @@ class Number(models.Model):
             vals.setdefault('fs_fifo_id', False)
         return super().write(vals)
 
+    @api.model
+    def _find_by_did(self, destination):
+        """Find the connect.number for an inbound destination, tolerating an
+        optional leading '+' mismatch between the trunk format and the stored
+        DID (e.g. trunk sends ``41215121140`` while the DID is stored as
+        ``+41215121140`` or vice-versa). Exact match wins; only if none is
+        found do we try the toggled-'+' form."""
+        if not destination:
+            return self.browse()
+        number = self.search([('phone_number', '=', destination)], limit=1)
+        if not number:
+            alt = destination[1:] if destination.startswith('+') else '+' + destination
+            number = self.search([('phone_number', '=', alt)], limit=1)
+        return number
+
     def generate_dialplan(self, params):
         """Generate FreeSWITCH dialplan XML for inbound DID routing."""
         self.ensure_one()
@@ -32,8 +47,18 @@ class Number(models.Model):
         elif self.destination == 'fs_fifo' and self.fs_fifo_id:
             transfer_target = self.fs_fifo_id.exten_number or str(self.fs_fifo_id.id)
 
+        # Match the destination_number FreeSWITCH presents, which may arrive
+        # with or without the leading '+'. Anchor on the bare digits and make
+        # the '+' optional so either trunk format routes to the same DID.
+        # See specs/decisions/023-inbound-did-format-normalization.md.
+        raw = self.phone_number or ''
+        digits = raw[1:] if raw.startswith('+') else raw
+        number_regex = r'\+?' + re.escape(digits)
+
         return self.env['connect.freeswitch.template'].render('dialplan_inbound_did', {
-            'phone_number': re.escape(self.phone_number),
+            'number_regex': number_regex,
+            'did_label': digits,
+            'phone_number': raw,
             'number_id': self.id,
             'destination': self.destination,
             'transfer_target': transfer_target,

--- a/docs/admin/freeswitch-setup.md
+++ b/docs/admin/freeswitch-setup.md
@@ -363,6 +363,19 @@ If a SIP phone can make outgoing calls but does not ring for incoming calls:
     fs_cli -x "sofia profile external restart reloadxml"
     ```
 
+### Inbound call dropped with 404 (DID format mismatch)
+
+Inbound DID matching tolerates an optional leading `+`: a number stored as
+`+41215121140` matches a trunk that delivers `41215121140`, and vice-versa.
+You do **not** need to match the trunk's exact E.164/national format when
+entering the DID under **Connect > PBX > Numbers**.
+
+If an inbound call still drops with a 404, the delivered digits themselves do
+not match. Check the `destination_number` the trunk actually sends (Odoo debug
+log, or `fs_cli` console at debug level) and make sure the stored DID's digits
+match it — differences beyond a leading `+` (e.g. an extra national prefix) are
+not normalized and require the stored number to match the delivered digits.
+
 ## Troubleshooting
 
 ### No audio on calls

--- a/specs/decisions/023-inbound-did-format-normalization.md
+++ b/specs/decisions/023-inbound-did-format-normalization.md
@@ -1,0 +1,76 @@
+# ADR-023: Normalize inbound DID `+`-format in dialplan regex and lookup
+
+## Status
+Accepted
+
+## Context
+
+Inbound DID routing matched calls by rendering a FreeSWITCH dialplan regex
+from the **canonical** stored `connect.number.phone_number`. The core field
+(`connect/models/number.py`) is a free-form `Char` with no normalization, so
+admins store DIDs as `+41215121140`, `41215121140`, `0041…`, etc. — while a
+trunk delivers `destination_number` in whatever format it chooses.
+
+`connect_freeswitch.controllers.freeswitch_xml._route_inbound` looked the
+number up by exact `phone_number`, then retried with a `+` **prepended**
+(one direction only). On a hit it called
+`connect.number.generate_dialplan`, which rendered
+`dialplan_inbound_did` with `phone_number = re.escape(self.phone_number)`,
+emitting:
+
+```xml
+<extension name="did_+41215121140">
+  <condition field="destination_number" expression="^\+41215121140$">
+```
+
+So with a stored DID `+41215121140` and peoplefone sending
+`destination_number=41215121140`, the **lookup** succeeded (via the
+`+`-prepend) but the rendered regex `^\+41215121140$` did **not** match the
+FreeSWITCH-side `41215121140`, and the call fell through to the 404
+`unmatched_inbound` extension. REISO worked around it by storing all DIDs
+without `+`; the reverse trunk format then breaks the same way, and the
+lookup never even handled stored-without-`+` / incoming-with-`+`.
+
+## Decision
+
+Make both the regex and the record lookup tolerant of an optional leading
+`+`, sourced from the trusted stored number:
+
+1. **Regex (Option B).** `generate_dialplan` strips a single leading `+`
+   from `phone_number`, `re.escape`s the bare digits, and renders
+   `expression="^\+?<digits>$"` via a new `number_regex` template variable.
+   This deterministically matches **both** `41215121140` and `+41215121140`.
+   The extension name uses a clean `did_label` (digits, no `+`); the raw
+   `phone_number` is still passed for any out-of-tree custom template.
+
+2. **Symmetric lookup.** The asymmetric inline search is replaced by
+   `connect.number._find_by_did(destination)` on the FreeSWITCH `_inherit`
+   (next to `generate_dialplan`): exact match first, then the toggled-`+`
+   form, in either direction; empty/falsy destination returns an empty
+   recordset. The controller becomes a one-liner.
+
+## Alternatives considered
+
+- **Option A — anchor the regex on the live incoming `destination_number`.**
+  Rejected. FreeSWITCH caches dialplan XML (mod_xml_curl), so emitting a
+  different regex per call makes the routing table non-deterministic: a
+  cached response from a `+`-form call would 404 a later no-`+` call,
+  re-creating the bug. It also pipes an untrusted, possibly spoofed
+  `destination_number` straight into the regex we emit. The issue suggested
+  "A + B together," but once B makes `+` optional, A adds no coverage (any
+  format difference beyond `+` fails `_find_by_did` before the template is
+  ever reached) and only adds risk.
+
+- **Normalize `phone_number` at write-time (store canonical E.164).**
+  Rejected for this fix — a broader change requiring data migration of
+  existing DIDs and a normalization policy across all trunk formats. The
+  optional-`+` regex solves the reported correctness bug without touching
+  stored data. Full number normalization remains a possible future change.
+
+## Cross-branch backport
+
+Per `CLAUDE.md` versioning rules, the same fix ports to the `18.0` branch
+with the aligned tail version: `connect_freeswitch` moves
+`19.0.1.10.0 → 19.0.1.10.1` and `18.0.1.10.0 → 18.0.1.10.1`. No schema
+change, so no migration script is required. The backport ships as a
+separate PR.


### PR DESCRIPTION
## Problem

Closes #42.

Inbound DID routing rendered the FreeSWITCH dialplan condition regex from the **canonical stored** `phone_number` (`re.escape(self.phone_number)`). So a DID stored as `+41215121140` produced `^\+41215121140$`, which did **not** match a trunk (e.g. peoplefone) delivering `destination_number=41215121140` — the lookup matched via a `+`-prepend, but the rendered regex did not, and the call dropped **404**. The lookup was also asymmetric: it never handled the reverse (stored without `+`, trunk sends `+…`).

## Fix

- **Regex (Option B):** `connect.number.generate_dialplan` now sources the regex from the stored number's bare digits and makes the leading `+` optional — `^\+?<digits>$` — which deterministically matches **both** `41215121140` and `+41215121140`.
- **Symmetric lookup:** new `connect.number._find_by_did(destination)` tolerates the `+`/no-`+` mismatch in both directions (exact match wins, then the toggled-`+` form). The controller `_route_inbound` becomes a one-liner.
- Template `dialplan_inbound_did` updated (`number_regex` for the condition, `did_label` for the extension name; `phone_number` still passed for custom templates).

We deliberately **reject Option A** (anchoring the regex on the live incoming destination): FreeSWITCH caches dialplan XML, so a per-call regex is non-deterministic and could re-introduce the 404 on a cached response. Rationale captured in `specs/decisions/023-inbound-did-format-normalization.md`.

## Tests

`tests_suite` adds `TestInboundDidRouting` (8 cases): the rendered regex matches the destination both with and without a leading `+` for both storage variants; a different number does not match; `_find_by_did` is symmetric with exact-match precedence and returns empty for empty/unmatched input; no `StrictUndefined`; `odoo_number_id`/`did_` name render against the real DB template.

Verified green via Oduflow `run_odoo_tests connect_freeswitch`:
```
connect_freeswitch: 0 failed, 0 error(s) of 8 tests
```

## Docs

- `specs/decisions/023-inbound-did-format-normalization.md` (new ADR)
- `docs/admin/freeswitch-setup.md` — troubleshooting note on `+`-tolerant DID matching

## Notes

- `connect_freeswitch` manifest bumped `19.0.1.10.0` → `19.0.1.10.1`.
- Backport to `18.0` ships as a separate PR (`18.0.1.10.1`).