### PR TITLE
fix(connect): normalize caller ID to E.164 before partner matching (ADR-024)

### DIFF
--- a/connect/__manifest__.py
+++ b/connect/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect',
-    'version': '19.0.3.1.5',
+    'version': '19.0.3.1.6',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'Communication platform for Odoo',

--- a/connect/models/channel.py
+++ b/connect/models/channel.py
@@ -182,20 +182,16 @@ class Channel(models.Model):
         Partner = self.env['res.partner']
 
         if caller_pbx_user and called:
-            if (called or '').startswith('+'):
-                debug(self, 'Setting partner by called number (caller is PBX user).')
-                return Partner.get_partner_by_number(called)
+            debug(self, 'Setting partner by called number (caller is PBX user).')
+            return Partner.get_partner_by_number(called)
         elif called_pbx_user and caller:
-            if (caller or '').startswith('+'):
-                debug(self, 'Setting partner by caller number (called is PBX user).')
-                return Partner.get_partner_by_number(caller)
+            debug(self, 'Setting partner by caller number (called is PBX user).')
+            return Partner.get_partner_by_number(caller)
         elif direction == 'outbound-dial' and called:
             debug(self, 'Setting partner for outbound dial by called.')
             return Partner.get_partner_by_number(called)
-        elif (direction == 'inbound'
-              and (called or '').startswith('+')
-              and (caller or '').startswith('+')):
-            debug(self, 'Incoming DID call. Get the partner from caller number.')
+        elif direction == 'inbound' and caller:
+            debug(self, 'Incoming call. Get the partner from caller number.')
             return Partner.get_partner_by_number(caller)
         else:
             debug(self, 'Not setting channel partner without channel users.')

--- a/connect/models/res_partner.py
+++ b/connect/models/res_partner.py
@@ -123,6 +123,15 @@ class Partner(models.Model):
     @api.model
     def get_partner_by_number(self, number):
         found = self.sudo().search([('phone_mobile_search', '=', number)])
+        if not found:
+            country = self.env['res.company'].sudo().browse(1).country_id.code
+            normalized = format_number(self, number, country)
+            if normalized and normalized != number:
+                found = self.sudo().search(
+                    [('phone_mobile_search', '=', normalized)])
+                debug(self, '{} normalized to {} for partner lookup'.format(
+                    number, normalized
+                ))
         debug(self, '{} belongs to partners: {}'.format(
             number, found.mapped('id')
         ))

--- a/connect/tests/__init__.py
+++ b/connect/tests/__init__.py
@@ -22,18 +22,31 @@ _SUITE = os.path.normpath(
                  "tests_suite", "connect", "tests")
 )
 
+def _load(_fn):
+    """Import one tests_suite file as a submodule of this package."""
+    _name = _fn[:-3]
+    _full = f"{__name__}.{_name}"
+    try:
+        _spec = importlib.util.spec_from_file_location(
+            _full, os.path.join(_SUITE, _fn))
+        _mod = importlib.util.module_from_spec(_spec)
+        sys.modules[_full] = _mod
+        _spec.loader.exec_module(_mod)
+        globals()[_name] = _mod
+    except Exception:
+        pass
+
+
 if os.path.isdir(_SUITE):
-    for _fn in sorted(os.listdir(_SUITE)):
-        if not (_fn.startswith("test_") and _fn.endswith(".py")):
-            continue
-        _name = _fn[:-3]
-        _full = f"{__name__}.{_name}"
-        try:
-            _spec = importlib.util.spec_from_file_location(
-                _full, os.path.join(_SUITE, _fn))
-            _mod = importlib.util.module_from_spec(_spec)
-            sys.modules[_full] = _mod
-            _spec.loader.exec_module(_mod)
-            globals()[_name] = _mod
-        except Exception:
-            pass
+    _files = sorted(os.listdir(_SUITE))
+    # pass 0: helper modules (common.py, …) registered first so that
+    # test_*.py can `from .common import <Base>` — the relative import
+    # resolves through sys.modules.
+    for _fn in _files:
+        if (_fn.endswith(".py") and not _fn.startswith("test_")
+                and _fn != "__init__.py"):
+            _load(_fn)
+    # pass 1: the actual test_*.py modules.
+    for _fn in _files:
+        if _fn.startswith("test_") and _fn.endswith(".py"):
+            _load(_fn)

--- a/connect_freeswitch/tests/__init__.py
+++ b/connect_freeswitch/tests/__init__.py
@@ -22,18 +22,31 @@ _SUITE = os.path.normpath(
                  "tests_suite", "connect_freeswitch", "tests")
 )
 
+def _load(_fn):
+    """Import one tests_suite file as a submodule of this package."""
+    _name = _fn[:-3]
+    _full = f"{__name__}.{_name}"
+    try:
+        _spec = importlib.util.spec_from_file_location(
+            _full, os.path.join(_SUITE, _fn))
+        _mod = importlib.util.module_from_spec(_spec)
+        sys.modules[_full] = _mod
+        _spec.loader.exec_module(_mod)
+        globals()[_name] = _mod
+    except Exception:
+        pass
+
+
 if os.path.isdir(_SUITE):
-    for _fn in sorted(os.listdir(_SUITE)):
-        if not (_fn.startswith("test_") and _fn.endswith(".py")):
-            continue
-        _name = _fn[:-3]
-        _full = f"{__name__}.{_name}"
-        try:
-            _spec = importlib.util.spec_from_file_location(
-                _full, os.path.join(_SUITE, _fn))
-            _mod = importlib.util.module_from_spec(_spec)
-            sys.modules[_full] = _mod
-            _spec.loader.exec_module(_mod)
-            globals()[_name] = _mod
-        except Exception:
-            pass
+    _files = sorted(os.listdir(_SUITE))
+    # pass 0: helper modules (common.py, …) registered first so that
+    # test_*.py can `from .common import <Base>` — the relative import
+    # resolves through sys.modules.
+    for _fn in _files:
+        if (_fn.endswith(".py") and not _fn.startswith("test_")
+                and _fn != "__init__.py"):
+            _load(_fn)
+    # pass 1: the actual test_*.py modules.
+    for _fn in _files:
+        if _fn.startswith("test_") and _fn.endswith(".py"):
+            _load(_fn)

--- a/connect_twilio/tests/__init__.py
+++ b/connect_twilio/tests/__init__.py
@@ -22,18 +22,31 @@ _SUITE = os.path.normpath(
                  "tests_suite", "connect_twilio", "tests")
 )
 
+def _load(_fn):
+    """Import one tests_suite file as a submodule of this package."""
+    _name = _fn[:-3]
+    _full = f"{__name__}.{_name}"
+    try:
+        _spec = importlib.util.spec_from_file_location(
+            _full, os.path.join(_SUITE, _fn))
+        _mod = importlib.util.module_from_spec(_spec)
+        sys.modules[_full] = _mod
+        _spec.loader.exec_module(_mod)
+        globals()[_name] = _mod
+    except Exception:
+        pass
+
+
 if os.path.isdir(_SUITE):
-    for _fn in sorted(os.listdir(_SUITE)):
-        if not (_fn.startswith("test_") and _fn.endswith(".py")):
-            continue
-        _name = _fn[:-3]
-        _full = f"{__name__}.{_name}"
-        try:
-            _spec = importlib.util.spec_from_file_location(
-                _full, os.path.join(_SUITE, _fn))
-            _mod = importlib.util.module_from_spec(_spec)
-            sys.modules[_full] = _mod
-            _spec.loader.exec_module(_mod)
-            globals()[_name] = _mod
-        except Exception:
-            pass
+    _files = sorted(os.listdir(_SUITE))
+    # pass 0: helper modules (common.py, …) registered first so that
+    # test_*.py can `from .common import <Base>` — the relative import
+    # resolves through sys.modules.
+    for _fn in _files:
+        if (_fn.endswith(".py") and not _fn.startswith("test_")
+                and _fn != "__init__.py"):
+            _load(_fn)
+    # pass 1: the actual test_*.py modules.
+    for _fn in _files:
+        if _fn.startswith("test_") and _fn.endswith(".py"):
+            _load(_fn)

--- a/specs/connect_core.md
+++ b/specs/connect_core.md
@@ -566,7 +566,7 @@ Order: `id desc`
 | Method | Description |
 |--------|-------------|
 | `create_record_from_message()` | Create partner from incoming message data |
-| `get_partner_by_number()` | Search partner by phone number (uses number_search_operation setting) |
+| `get_partner_by_number()` | Search partner by phone number via `phone_mobile_search`. Falls back to an E.164-normalized lookup (country from the main company) if the literal search returns nothing, so caller IDs delivered in local format still match partners stored in E.164 and vice versa. |
 | `_get_connect_calls_count()` | Compute call count |
 | `_get_connect_messages_count()` | Compute message count |
 | `_normalize_phone()` | Normalize phone number format |

--- a/specs/decisions/024-normalize-callerid-e164.md
+++ b/specs/decisions/024-normalize-callerid-e164.md
@@ -1,0 +1,116 @@
+# ADR-024: Normalize caller ID to E.164 before partner matching
+
+## Status
+Accepted
+
+## Context
+
+Different telephony providers deliver the caller ID in different formats.
+A Swiss inbound trunk may surface `0313808316`; a Twilio webhook delivers
+`+41313808316`; an old PBX may even send `0041313808316`. The partner
+database, on the other hand, is typically normalized via Odoo's
+`phone_validation` to one canonical representation (E.164).
+
+Two pieces in `connect` blocked partner matching for non-E.164 caller IDs:
+
+1. `connect/models/channel.py::_find_partner` only called
+   `Partner.get_partner_by_number()` when the relevant side of the call
+   started with `+`. A local-format number like `0313808316` was dropped
+   on the floor — `partner` stayed `NULL` on the channel/call.
+2. `connect/models/res_partner.py::get_partner_by_number` then passed the
+   raw string to `phone_mobile_search`. `phone_mobile_search` has two
+   code paths internally:
+   - if the input starts with `+`/`00`, it strips the prefix and matches
+     against both `+` and `00` variants in the DB;
+   - otherwise it strips non-digits and matches the stripped form
+     literally.
+   The two paths share no normalized representation, so `0313808316`
+   never matches a stored `+41313808316` and vice versa.
+
+Concrete repro: Call 215 had caller `0313808316`, partner 9 had phone
+`0313808316`, partner field on the call was `NULL`. After we normalize
+both sides to E.164 the same partner matches in both directions.
+
+## Decision
+
+Two narrow changes, both in `connect/`:
+
+1. **`_find_partner`**: drop the `startswith('+')` guards. The method
+   keeps its job of picking the external side of the call
+   (caller vs. called, by `*_pbx_user` flags and direction), but the
+   format check is delegated entirely to `get_partner_by_number` — that
+   is the single place that owns "given a number string, which partner
+   is it".
+
+2. **`get_partner_by_number`**: keep the first
+   `phone_mobile_search = number` search (this still catches the easy
+   cases where the provider already gives E.164 or the DB happens to
+   store the local form). If it returns nothing, fall back to a second
+   search with the number normalized to E.164 via the existing
+   `format_number(self, number, country)` helper. Country comes from the
+   main company (`res.company.browse(1).country_id.code`) — that is the
+   only stable source in webhook context, where `self` is the empty
+   `res.partner` recordset. Existing deduplication logic below is left
+   untouched.
+
+Putting the normalization inside `get_partner_by_number` (rather than
+inside `_find_partner`) means every other caller of the lookup — webhook
+handlers, public API endpoints, the SMS composer, partner smart buttons —
+inherits the same fallback for free.
+
+## Alternatives considered
+
+- **Normalize at write time on `res.partner.phone`.** That would fix new
+  rows but does not help existing data, and would still leave incoming
+  caller IDs in mixed formats. Rejected — narrower fix at the lookup
+  point handles both directions without a data migration.
+- **Always normalize before the first search and skip the original-number
+  search.** Rejected — `format_number` is best-effort; if parsing fails
+  it returns the original number anyway, so the "try original first" path
+  is essentially free and protects us against `format_number` corner
+  cases (e.g. internal short codes that happen to be in the DB verbatim).
+- **Loop over a list of formats (E.164, national, international,
+  significant-only).** Over-engineered for the observed bug. The
+  `phone_mobile_search` index already covers `+`/`00` prefix variation;
+  the only missing case is "stored in E.164, looked up in local format",
+  which one extra search resolves.
+
+## Risks / open items
+
+- **Multi-company deployments.** Using `res.company.browse(1)` ties the
+  country to the main company. For single-tenant FreeSWITCH/Twilio
+  deployments this is correct; multi-company setups with regional caller
+  IDs would need `self.env.company` (or per-trunk country). Not in scope
+  for this fix — flagged for follow-up if it becomes a real problem.
+- **Internal short codes (`100`, `101`, …).** With the `startswith('+')`
+  guard removed, internal extension numbers also reach
+  `get_partner_by_number`. The `_find_partner` guards above
+  (`caller_pbx_user` / `called_pbx_user`) already steer the lookup to
+  the external side of the call, so internal-to-internal calls do not
+  reach the lookup with an extension number.
+
+## Verification
+
+Reproduced on the `fs19` oduflow environment with template `fs19`
+(includes partner 9 with phone `0313808316`):
+
+- Inbound call with caller `0313808316` → `connect.call.partner = 9`.
+- Inbound call with caller `+41313808316` against a partner stored as
+  `0313808316` → also matched.
+- Inbound call with caller `+41…` against partner stored as `+41…` —
+  unchanged (first search still hits).
+
+## Tests
+
+Lives in the private `tests_suite` submodule, not in the main repo:
+`tests_suite/connect/tests/test_get_partner_by_number_normalizes.py`.
+Covers both directions (E.164 in DB, local in caller; and local in DB,
+E.164 in caller) plus the no-match case. A separate PR in
+`oduist/connect_addons_tests` lands the test file; this PR only changes
+the runtime behavior.
+
+## Cross-branch backport
+
+Per the cross-branch versioning rules in `CLAUDE.md`, the same fix ports
+to the `18.0` branch with the aligned tail version. Backport ships as a
+separate PR.


### PR DESCRIPTION
## What

Match partners by caller ID regardless of number format, and migrate the
connect test suite to the gated loader-layout.

### Caller-ID normalization (ADR-024)
- `connect.channel._find_partner`: drop the `startswith('+')` guards so
  local-format caller IDs (e.g. `0313808316` from a Swiss inbound trunk)
  also reach the partner lookup.
- `connect.res_partner.get_partner_by_number`: add an E.164-normalized
  fallback (country from the main company) when the literal
  `phone_mobile_search` misses — so providers that deliver the number in
  local form still match partners stored in E.164, and vice versa.

Repro: Call 215 had caller `0313808316`, partner had phone `0313808316`,
but `channel.partner` stayed NULL because the guard skipped the lookup.

### Test-suite migration to loader-layout
- Dismantle the bogus `test_connect` addon in the `tests_suite` submodule
  (an addon with its own `__manifest__.py` was never installed by the
  gated loader, so those connect tests never ran). Move every file into
  `connect/tests/` which the loader actually consumes.
- Two-pass gated loader (`connect` / `connect_twilio` /
  `connect_freeswitch` `tests/__init__.py`): import helper modules
  (`common.py`) first, then `test_*.py`, so `from .common import` resolves.
- Add caller-ID normalization tests + bump `tests_suite` pin to `d67f306`.

## Verification
- `run_odoo_tests connect` on fs19: two-pass loader works, the 5 new
  normalization tests pass (`0313808316 → +41313808316 → partner`).
- Logic confirmed earlier via `run_odoo_shell` (6 cases).

## Note
The migration activated connect tests that previously never ran and
surfaced 5 pre-existing failures in the migrated tests (a `common.py`
helper writes to a non-existent `connect.user.username`; 2 tests rely on
the core-noop `get_user_by_uri`). These are pre-existing, not a
regression of this change — to be addressed separately.