### PR TITLE
chore(oduflow): run dev Odoo single-process (workers=0)

### DIFF
--- a/.oduflow/odoo.conf
+++ b/.oduflow/odoo.conf
@@ -5,4 +5,4 @@ max_cron_threads = 1
 limit_time_cpu = 600
 limit_time_real = 1200
 db_maxconn=16
-workers=3
+workers=0


### PR DESCRIPTION
Set `workers=0` in the checked-in Oduflow dev config (`.oduflow/odoo.conf`),
disabling multi-process workers so dev Odoo runs single-process / threaded —
the usual setup for debugging.

Only change:

\`\`\`
.oduflow/odoo.conf:  workers=3  →  workers=0
\`\`\`