### PR TITLE
fix(freeswitch): honour odoo_call_direction for CDR direction (#43)

### DIFF
--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.10.2',
+    'version': '19.0.1.10.3',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',

--- a/connect_freeswitch/controllers/freeswitch_cdr.py
+++ b/connect_freeswitch/controllers/freeswitch_cdr.py
@@ -116,6 +116,7 @@ class FreeSwitchCDRController(http.Controller):
         other_leg_uuid = None
         chain_id = None
         odoo_number_id = None
+        odoo_call_direction = None
 
         if variables is not None:
             # Click-to-call originates `user/<login>@<domain>` and the
@@ -190,6 +191,16 @@ class FreeSwitchCDRController(http.Controller):
 
             odoo_number_id = self._xml_text(variables, 'odoo_number_id')
 
+            # The dialplan stamps the business-logic call direction on the
+            # channel (`odoo_call_direction`: 'inbound' on inbound DID
+            # routes, 'outgoing' on outgoing routes). It is a plain word,
+            # so no URL-decoding is needed. Prefer it downstream over
+            # FreeSWITCH's native per-leg direction, which marks the UA /
+            # originate leg of an outbound call as 'inbound' and mislabels
+            # such calls as incoming (issue #43).
+            odoo_call_direction = self._xml_text(
+                variables, 'odoo_call_direction') or None
+
         return {
             'uuid': uuid,
             'caller': caller,
@@ -201,6 +212,7 @@ class FreeSwitchCDRController(http.Controller):
             'called_pbx_user_id': called_pbx_user_id,
             'other_leg_uuid': other_leg_uuid,
             'chain_id': chain_id,
+            'odoo_call_direction': odoo_call_direction,
             'odoo_number_id': int(odoo_number_id) if odoo_number_id else None,
         }
 

--- a/connect_freeswitch/models/call.py
+++ b/connect_freeswitch/models/call.py
@@ -331,6 +331,9 @@ class Call(models.Model):
                 caller_pbx_user_id (int): connect.user ID from channel variable (optional)
                 called_pbx_user_id (int): connect.user ID (optional)
                 other_leg_uuid (str): Other leg UUID for linking (optional)
+                odoo_call_direction (str): dialplan-stamped business
+                    direction, 'inbound' or 'outgoing' (optional; preferred
+                    over the native FreeSWITCH `direction` when present)
 
         Returns:
             call id or False
@@ -365,17 +368,37 @@ class Call(models.Model):
                 "SELECT pg_advisory_unlock(hashtext(%s))", [chain_key])
 
     @api.model
+    def _cdr_technical_direction(self, cdr_data):
+        """Resolve the Twilio-compatible technical_direction for a CDR.
+
+        Prefer the business-logic direction the dialplan stamps on the
+        channel (`odoo_call_direction`) over FreeSWITCH's per-leg native
+        direction. originate-launched legs and the UA leg of an outgoing
+        call are `inbound` from FreeSWITCH's own perspective and would
+        otherwise be mislabelled as incoming (issue #43). Fall back to the
+        native direction when the variable is absent (e.g. a raw originate
+        that bypasses the dialplan).
+        """
+        odoo_direction = cdr_data.get('odoo_call_direction')
+        if odoo_direction == 'outgoing':
+            return 'outbound-api'
+        if odoo_direction == 'inbound':
+            return 'inbound'
+        return (
+            'outbound-api'
+            if cdr_data.get('direction') == 'outbound'
+            else 'inbound'
+        )
+
+    @api.model
     def _process_cdr_locked(self, cdr_data):
         """Inner CDR processing, called while holding the chain lock."""
         status = HANGUP_CAUSE_MAP.get(
             cdr_data.get('hangup_cause', ''), 'failed')
 
-        # Map FreeSWITCH direction to Twilio-compatible technical_direction
-        fs_direction = cdr_data.get('direction', '')
-        if fs_direction == 'outbound':
-            technical_direction = 'outbound-api'
-        else:
-            technical_direction = 'inbound'
+        # Map the call direction to a Twilio-compatible technical_direction,
+        # preferring the dialplan-stamped odoo_call_direction (issue #43).
+        technical_direction = self._cdr_technical_direction(cdr_data)
 
         generic_params = {
             'sid': cdr_data['uuid'],

--- a/specs/connect_freeswitch.md
+++ b/specs/connect_freeswitch.md
@@ -249,6 +249,25 @@ Operational guide for admins lives in **`docs/admin/firewall.md`**.
 
 ---
 
+## CDR webhook & call direction
+
+`controllers/freeswitch_cdr.py` receives `mod_xml_cdr` POSTs at
+`/freeswitch/webhook/cdr`, parses the XML into a dict, and hands it to
+`connect.call.on_freeswitch_cdr`.
+
+Call **direction** is resolved from the dialplan-stamped business direction,
+not FreeSWITCH's transport-level direction. The dialplan sets
+`odoo_call_direction` (`inbound` on inbound DID routes, `outgoing` on outgoing
+routes — `data/fs_templates.xml`); `_parse_cdr_xml` reads it and
+`connect.call._cdr_technical_direction` maps it to `technical_direction`
+(`outgoing` → `outbound-api`, `inbound` → `inbound`). Only when the variable is
+absent does it fall back to FreeSWITCH's native `<channel_data><direction>`.
+This prevents `originate`-launched outbound calls — whose UA / origination leg
+is `inbound` from FreeSWITCH's own perspective — from being mislabelled as
+incoming. See **`specs/decisions/027-cdr-direction-from-dialplan-variable.md`**.
+
+---
+
 ## Tests
 
 `tests/test_firewall.py` (gated test suite — symlinked from
@@ -261,3 +280,8 @@ Operational guide for admins lives in **`docs/admin/firewall.md`**.
 * `_cron_cleanup` retention logic;
 * the Unban action (`is_banned` compute + `action_unban_ip`)
   with the service calls mocked out.
+
+`tests/test_cdr_direction.py` covers CDR direction resolution: `_parse_cdr_xml`
+extraction of `odoo_call_direction`, and `_cdr_technical_direction` preferring it
+over the native FreeSWITCH direction (the issue #43 regression) with the
+native-direction fallback.

--- a/specs/decisions/027-cdr-direction-from-dialplan-variable.md
+++ b/specs/decisions/027-cdr-direction-from-dialplan-variable.md
@@ -1,0 +1,75 @@
+# ADR-027: Resolve CDR call direction from the dialplan `odoo_call_direction` variable
+
+## Status
+Accepted
+
+## Context
+
+The FreeSWITCH CDR handler (`connect_freeswitch.controllers.freeswitch_cdr`)
+derives a call's direction from FreeSWITCH's **native per-leg direction**, read
+from `<channel_data><direction>` and mapped through:
+
+1. `_process_cdr_locked` (`connect_freeswitch/models/call.py`):
+   FS `outbound` → `technical_direction='outbound-api'`, else `'inbound'`.
+2. `_determine_direction` (core `connect/models/call.py`):
+   `outbound-api` → `outgoing`; `inbound` **with** `caller_pbx_user` →
+   `outgoing`; `inbound` **without** `caller_pbx_user` → `incoming`.
+
+FreeSWITCH's native direction is a *transport* property: the UA / originate leg
+of an **outbound** call is `inbound` from FS's own perspective (the UA sends its
+INVITE *into* FS). When a call is launched via `fs_cli -x "originate ..."` (or any
+path that doesn't seed `caller_pbx_user`), that leg lands at
+`technical_direction='inbound'` with no `caller_pbx_user`, so
+`_determine_direction` returns `incoming` for a call that actually left the system
+outbound. Reproduced during REISO outbound testing (issue #43).
+
+The dialplan already records the **business-logic** direction on the channel — it
+sets `odoo_call_direction=inbound` on inbound DID routes and
+`odoo_call_direction=outgoing` on outgoing routes (`data/fs_templates.xml`) — but
+the CDR processor never read that variable.
+
+## Decision
+
+Honour `odoo_call_direction` in the CDR handler; fall back to the native FS
+direction only when it is absent.
+
+1. **Parse it.** `_parse_cdr_xml` extracts `odoo_call_direction` from the CDR
+   `<variables>` (a plain word, so no URL-decoding) and returns it on the
+   `cdr_data` dict (`None` when absent).
+
+2. **Prefer it.** A new pure helper
+   `connect.call._cdr_technical_direction(cdr_data)` resolves
+   `technical_direction`: `odoo_call_direction='outgoing'` → `outbound-api`,
+   `='inbound'` → `inbound`, otherwise the previous native-direction mapping
+   (`direction='outbound'` → `outbound-api`, else `inbound`).
+   `_process_cdr_locked` calls the helper instead of inlining the mapping.
+
+This keeps the fix entirely inside `connect_freeswitch`: core's
+`_determine_direction` and the provider-agnostic boundary are untouched. The
+B-leg of an outbound call and both legs of an inbound DID call do not carry
+`odoo_call_direction` (the dialplan `set` is not `export`ed), so they fall through
+to the unchanged native mapping — no regression. Call direction is decided by the
+first (parent-less) leg in `process_call_event`, which for an outbound call is the
+UA / originate leg this fix corrects.
+
+## Alternatives considered
+
+- **Change core `_determine_direction` to accept an explicit direction.**
+  Rejected: it pushes FreeSWITCH-specific knowledge into the technology-agnostic
+  core and widens the core/provider boundary for a provider-local concern.
+
+- **Seed `caller_pbx_user` on every originate.** Rejected: it only helps Odoo's
+  own click-to-call path and does nothing for raw `fs_cli` originates or any
+  third-party origination — the exact scenario in the report. The dialplan
+  variable is authoritative regardless of who launched the call.
+
+- **Infer direction from the channel name / gateway leg.** Rejected as brittle:
+  it re-derives, by string heuristics, the very fact the dialplan already states
+  explicitly.
+
+## Cross-branch backport
+
+Per `CLAUDE.md` versioning rules, the same fix ports to the `18.0` branch with the
+aligned tail version: `connect_freeswitch` moves `19.0.1.10.2 → 19.0.1.10.3` and
+`18.0.1.10.2 → 18.0.1.10.3`. Code-only change — no schema change and no migration
+script. The backport ships as a separate PR.


### PR DESCRIPTION
## Problem

Calls originated via `fs_cli -x "originate ..."` (or any path that doesn't seed `caller_pbx_user`) were recorded as `direction=incoming` even though they left the system outbound. Reproduced during REISO outbound testing.

**Root cause:** the CDR handler derived direction from FreeSWITCH's *native* per-leg direction (`<channel_data><direction>`), which is `inbound` for the UA / origination leg of an outbound call. With no `caller_pbx_user` on that leg, core `_determine_direction` then returned `incoming`. The dialplan already stamps the business-logic direction on the channel via `odoo_call_direction` (`inbound` on inbound DID routes, `outgoing` on outgoing routes), but the CDR processor never read it.

## Fix

Honour `odoo_call_direction` in the CDR handler; fall back to the native FS direction only when it is absent.

- `controllers/freeswitch_cdr.py` — `_parse_cdr_xml` extracts `odoo_call_direction` from `<variables>` and returns it on `cdr_data` (`None` when absent).
- `models/call.py` — new pure helper `connect.call._cdr_technical_direction(cdr_data)` prefers `odoo_call_direction` (`outgoing`→`outbound-api`, `inbound`→`inbound`), else falls back to the previous native-direction mapping. `_process_cdr_locked` calls it instead of the inline mapping.

The fix stays entirely inside `connect_freeswitch`; core `_determine_direction` and the provider-agnostic boundary are untouched. The B-leg of an outbound call and both legs of an inbound DID call don't carry `odoo_call_direction` (the dialplan `set` isn't `export`ed), so they fall through to the unchanged native mapping — no regression.

## Docs / spec

- ADR-027 (`specs/decisions/027-cdr-direction-from-dialplan-variable.md`).
- `specs/connect_freeswitch.md` — new "CDR webhook & call direction" section.
- `connect_freeswitch` version `19.0.1.10.2 → 19.0.1.10.3`. Code-only — no migration, no Docker image rebuild.

## Tests

New gated test `tests_suite/connect_freeswitch/tests/test_cdr_direction.py` (added to the private tests submodule separately): `_parse_cdr_xml` extraction + `_cdr_technical_direction` mapping, including the #43 regression (native `inbound` + dialplan `outgoing` → `outbound-api`).

Verified in an oduflow Odoo 19 environment on this branch (rebased onto current `19.0`): `connect_freeswitch` upgrades cleanly and **10/10 CDR-direction tests pass, 0 failures**.

Fixes #43