### PR TITLE
fix(freeswitch): distinguish Server Status failure modes (#40)

### DIFF
--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.10.2',
+    'version': '19.0.1.10.3',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',

--- a/connect_freeswitch/models/settings.py
+++ b/connect_freeswitch/models/settings.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 import re
+import socket
 import xml.etree.ElementTree as ET
 import xmlrpc.client
 
@@ -208,11 +209,17 @@ class Settings(models.Model):
         return res
 
     @api.model
-    def freeswitch_api(self, command, args=''):
-        """Execute a FreeSWITCH API command via mod_xml_rpc.
+    def _freeswitch_rpc(self, command, args=''):
+        """Low-level mod_xml_rpc call that classifies the failure mode.
 
-        Returns the command response string, or False on failure.
-        Errors are logged but never raised to avoid blocking callers.
+        Returns a ``(result, error)`` tuple:
+        - on success ``(response_string, None)``;
+        - on failure ``(None, error)`` where ``error`` is one of
+          ``NOT CONFIGURED`` / ``UNREACHABLE`` / ``AUTH FAILED`` /
+          ``INVALID RESPONSE``.
+
+        Errors are logged but never raised, so callers are never blocked
+        by FS connectivity issues.
         """
         host = self.get_param('freeswitch_xmlrpc_host')
         port = self.get_param('freeswitch_xmlrpc_port') or 8080
@@ -220,31 +227,58 @@ class Settings(models.Model):
         password = self.sudo().get_param('freeswitch_xmlrpc_password')
         if not host:
             logger.warning("FreeSWITCH XML-RPC host not configured")
-            return False
+            return None, 'NOT CONFIGURED'
         url = "http://{}:{}@{}:{}/RPC2".format(user, password, host, port)
         try:
             server = xmlrpc.client.ServerProxy(url)
             result = server.freeswitch.api(command, args)
             logger.info("FreeSWITCH API %s %s: %s", command, args, result)
-            return result
+            return result, None
+        except xmlrpc.client.ProtocolError as e:
+            # HTTP-level error from mod_xml_rpc; 401 means bad credentials.
+            error = 'AUTH FAILED' if e.errcode == 401 else 'INVALID RESPONSE'
+            logger.error("FreeSWITCH XML-RPC protocol error (%s): %s",
+                         e.errcode, e.errmsg)
+            return None, error
+        except OSError as e:
+            # socket.timeout, ConnectionError, ConnectionRefusedError,
+            # socket.gaierror (DNS) — host configured but not reachable.
+            logger.error("FreeSWITCH XML-RPC unreachable: %s", e)
+            return None, 'UNREACHABLE'
         except Exception as e:
-            logger.error("FreeSWITCH XML-RPC error: %s", e)
-            return False
+            # xmlrpc.client.Fault, malformed XML, parse errors, etc.
+            logger.error("FreeSWITCH XML-RPC invalid response: %s", e)
+            return None, 'INVALID RESPONSE'
+
+    @api.model
+    def freeswitch_api(self, command, args=''):
+        """Execute a FreeSWITCH API command via mod_xml_rpc.
+
+        Returns the command response string, or False on failure.
+        Errors are logged but never raised to avoid blocking callers.
+        Use :meth:`_freeswitch_rpc` directly when the specific failure
+        mode is needed (e.g. to surface it in the status field).
+        """
+        result, error = self._freeswitch_rpc(command, args)
+        return result if error is None else False
 
     def check_freeswitch_status(self):
         """Fetch live status from FreeSWITCH and update display fields."""
         self.ensure_one()
         down_vals = {
-            'freeswitch_status': 'DOWN (unreachable)',
+            'freeswitch_status': '',
             'freeswitch_uptime': '',
             'freeswitch_calls': '',
             'freeswitch_registrations': '',
             'freeswitch_gateway_statuses': '',
         }
 
-        # 1. Basic status
-        status_response = self.freeswitch_api('status')
-        if not status_response:
+        # 1. Basic status — surface the specific failure mode (NOT
+        # CONFIGURED / UNREACHABLE / AUTH FAILED / INVALID RESPONSE)
+        # instead of a single misleading "DOWN" string.
+        status_response, status_error = self._freeswitch_rpc('status')
+        if status_error is not None:
+            down_vals['freeswitch_status'] = status_error
             self.write(down_vals)
             return
 

--- a/docs/admin/freeswitch-setup.md
+++ b/docs/admin/freeswitch-setup.md
@@ -102,6 +102,21 @@ XML-RPC settings enable Odoo to push commands to FreeSWITCH (e.g., reload gatewa
 
 When configured, Odoo automatically sends `sofia profile external restart reloadxml` to FreeSWITCH whenever SIP gateways are created, modified, or deleted. This ensures FreeSWITCH picks up gateway changes immediately without manual intervention.
 
+#### Checking server status
+
+The **CHECK STATUS** button on the FreeSWITCH settings tab probes the
+server over XML-RPC and writes the result to the **Server Status**
+field. When the probe fails, the field shows the specific reason so you
+know which side to fix:
+
+| Server Status | Meaning | What to do |
+|---------------|---------|------------|
+| `UP — <version>` | FreeSWITCH reachable and answering. | Nothing — healthy. |
+| `NOT CONFIGURED` | No XML-RPC host set in Odoo; no connection is attempted. | Fill in the XML-RPC Host (and port/user/password) above. |
+| `UNREACHABLE` | Host set but the TCP connection failed (firewall, closed port, wrong host/IP, DNS). | Check the host/port, that `mod_xml_rpc` is listening, and that the port is open between Odoo and FreeSWITCH. |
+| `AUTH FAILED` | Host reachable but `mod_xml_rpc` rejected the credentials (HTTP 401). | Fix the XML-RPC User / Password to match the FreeSWITCH side. |
+| `INVALID RESPONSE` | Server answered but the payload could not be parsed. | Check the FreeSWITCH logs and the `mod_xml_rpc` configuration. |
+
 ### Endpoints
 
 Navigate to **Connect > PBX > Endpoints** to configure user devices.

--- a/specs/connect_freeswitch.md
+++ b/specs/connect_freeswitch.md
@@ -63,6 +63,17 @@ firewall-related fields:
 * schedule a `/firewall/sync` POST via `cr.postcommit` whenever any
   `firewall_*` field changes.
 
+XML-RPC connectivity to FreeSWITCH (ADR-004, ADR-027):
+* `_freeswitch_rpc(command, args)` — low-level `mod_xml_rpc` call
+  returning a `(result, error)` tuple. `error` is `None` on success or
+  one of `NOT CONFIGURED` / `UNREACHABLE` / `AUTH FAILED` /
+  `INVALID RESPONSE`.
+* `freeswitch_api(command, args)` — thin wrapper returning the response
+  string or `False`; used wherever only success/failure matters.
+* `check_freeswitch_status()` — backs the **CHECK STATUS** button;
+  writes the specific failure reason into the read-only
+  `freeswitch_status` field so admins can tell the failure modes apart.
+
 ### firewall.py — firewall models
 
 | Model | Purpose |

--- a/specs/decisions/004-freeswitch-xml-rpc.md
+++ b/specs/decisions/004-freeswitch-xml-rpc.md
@@ -25,5 +25,5 @@ Use **mod_xml_rpc** (option 1).
 ## Implementation
 
 - New settings fields: `freeswitch_xmlrpc_host`, `freeswitch_xmlrpc_port`, `freeswitch_xmlrpc_user`, `freeswitch_xmlrpc_password` on `connect.settings`.
-- New method `freeswitch_api(command, args)` on `connect.settings` — catches all exceptions and logs errors without raising, so gateway CRUD is never blocked by FS connectivity issues.
+- New method `freeswitch_api(command, args)` on `connect.settings` — catches all exceptions and logs errors without raising, so gateway CRUD is never blocked by FS connectivity issues. (ADR-027 later split the connection logic into a `_freeswitch_rpc()` helper returning a `(result, error)` tuple so the Server Status field can distinguish the failure mode; `freeswitch_api()` keeps the same `response | False` contract.)
 - Gateway model (`connect.freeswitch.gateway`) overrides `create`, `write`, `unlink` to call `sofia profile external restart reloadxml` after each operation.

--- a/specs/decisions/027-freeswitch-status-failure-modes.md
+++ b/specs/decisions/027-freeswitch-status-failure-modes.md
@@ -1,0 +1,109 @@
+# ADR-027: FreeSWITCH Server Status distinguishes failure modes
+
+**Status:** Accepted
+**Date:** 2026-06-02
+
+## Context
+
+The **Server Status** field on `connect.settings` (FreeSWITCH tab) is
+populated by the `check_freeswitch_status` button. Its first probe
+calls `freeswitch_api('status')`, and on any falsy return the field was
+set to the single string `DOWN (unreachable)`.
+
+`freeswitch_api()` returns `False` for several genuinely distinct
+failure modes (see ADR-004 — it catches all exceptions and never
+raises, so gateway CRUD is never blocked):
+
+1. **Not configured** — no XML-RPC host set; no TCP connection is even
+   attempted.
+2. **Unreachable** — host configured but the TCP connection fails
+   (firewall, port closed, wrong host, DNS).
+3. **Auth failed** — host reachable but the credentials are wrong
+   (`mod_xml_rpc` returns HTTP 401).
+4. **Invalid response** — the server answered but the payload could not
+   be parsed (malformed XML, XML-RPC fault).
+
+Collapsing all four into `DOWN (unreachable)` is misleading: each needs
+a different operator action (set credentials in Odoo vs. open a port
+vs. fix the password vs. check the FS side). The gateway loop in the
+same method already classifies its own failures
+(`Unreachable` / `Not loaded` / `Parse error`); the top-level status
+had simply not caught up.
+
+## Options
+
+1. **Change `freeswitch_api()` to return the reason string on
+   failure.** Smallest diff at the call site, but `freeswitch_api()` is
+   called from four places (`status`, `show calls count`,
+   `sofia xmlstatus`, per-gateway `xmlstatus`), three of which rely on
+   the `response | False` contract and would mis-treat a reason string
+   (`'AUTH FAILED'`) as a successful response to parse. Rejected — it
+   silently breaks the other callers.
+2. **Add a low-level helper that returns a structured
+   `(result, error)` tuple, and keep `freeswitch_api()` as a thin
+   wrapper over it.** The three parsing call sites keep the
+   `response | False` contract unchanged; only the status probe opts in
+   to the richer result. Chosen.
+3. **Probe connectivity separately (e.g. a raw socket connect) before
+   calling the API.** Duplicates connection logic, races against the
+   real call, and cannot distinguish auth failure from a parse error.
+   Rejected.
+
+## Decision
+
+**Option 2.** New `connect.settings._freeswitch_rpc(command, args)`
+returns `(result, error)`:
+
+- success → `(response_string, None)`;
+- failure → `(None, error)` where `error` is one of the bare,
+  operator-facing strings `NOT CONFIGURED`, `UNREACHABLE`,
+  `AUTH FAILED`, `INVALID RESPONSE`.
+
+Mapping:
+
+| Condition | `error` |
+|-----------|---------|
+| `freeswitch_xmlrpc_host` empty | `NOT CONFIGURED` |
+| `xmlrpc.client.ProtocolError`, `errcode == 401` | `AUTH FAILED` |
+| `xmlrpc.client.ProtocolError`, other code | `INVALID RESPONSE` |
+| `OSError` (`socket.timeout`, `ConnectionError`, `ConnectionRefusedError`, `socket.gaierror`) | `UNREACHABLE` |
+| any other exception (`xmlrpc.client.Fault`, XML parse, …) | `INVALID RESPONSE` |
+
+`freeswitch_api()` becomes
+`result, error = self._freeswitch_rpc(...); return result if error is None else False`
+— its contract is unchanged, so the calls/registrations/gateway code
+paths are untouched.
+
+`check_freeswitch_status()` calls `_freeswitch_rpc('status')` for the
+first probe and writes the bare `error` string straight into
+`freeswitch_status`.
+
+### Why bare strings, not `DOWN (...)`
+
+The status field is the final, operator-facing value; the reason **is**
+the status. Prefixing every failure with `DOWN` is redundant and, for
+`NOT CONFIGURED`, inaccurate (the server may well be up — Odoo just was
+never told how to reach it). So the field now shows `UNREACHABLE`,
+`AUTH FAILED`, etc. directly.
+
+## Consequences
+
+- **Display change.** `DOWN (unreachable)` is replaced by one of
+  `NOT CONFIGURED` / `UNREACHABLE` / `AUTH FAILED` / `INVALID RESPONSE`.
+  Read-only field, no stored semantics depend on the old string.
+- **`freeswitch_api()` contract is preserved** — the three other
+  callers and any external callers see no behavioural change.
+- **New `import socket`** in `connect_freeswitch/models/settings.py`
+  for the `socket.timeout` / `socket.gaierror` documentation of intent
+  (both are `OSError` subclasses, caught via `except OSError`).
+- **Docs updated** — `docs/admin/freeswitch-setup.md` gains a Server
+  Status reference table mapping each value to the action to take.
+
+## References
+
+- ADR-004 — FreeSWITCH XML-RPC; established the
+  catch-all-and-return-`False` contract this ADR refines.
+- GitHub issue #40 — "`DOWN (unreachable)` is misleading — collapses
+  three distinct failure modes".
+- `connect_freeswitch/models/settings.py` — `_freeswitch_rpc()`,
+  `freeswitch_api()`, `check_freeswitch_status()`.


### PR DESCRIPTION
## Problem

The **Server Status** field on `connect.settings` (FreeSWITCH tab) showed
`DOWN (unreachable)` for *every* falsy `freeswitch_api()` result, collapsing
three genuinely distinct failure modes into one misleading string:

1. **NOT CONFIGURED** — no XML-RPC host/user/password; no TCP connect attempted.
2. **UNREACHABLE** — host set but TCP connect fails (firewall, closed port, DNS).
3. **AUTH FAILED** — host reachable but credentials rejected (HTTP 401).
4. **INVALID RESPONSE** — server answered but the payload could not be parsed.

Each needs a different operator action, so one string made troubleshooting harder.

## Fix

- New `connect.settings._freeswitch_rpc(command, args)` returns a `(result, error)`
  tuple classifying the failure as `NOT CONFIGURED` / `UNREACHABLE` /
  `AUTH FAILED` / `INVALID RESPONSE`.
- `freeswitch_api()` becomes a thin wrapper and keeps its `response | False`
  contract, so the calls/registrations/gateway probes are unchanged.
- `check_freeswitch_status()` writes the specific reason into `freeswitch_status`.

## Docs / specs

- `ADR-027` documents the decision; `ADR-004` + `specs/connect_freeswitch.md` updated.
- `docs/admin/freeswitch-setup.md` gains a Server Status reference table.
- Manifest `19.0.1.10.2 → 19.0.1.10.3`.

Closes #40