### PR TITLE
fix(tests): backport two-pass test loader to 18.0

### DIFF
--- a/connect/tests/__init__.py
+++ b/connect/tests/__init__.py
@@ -22,18 +22,31 @@ _SUITE = os.path.normpath(
                  "tests_suite", "connect", "tests")
 )
 
+def _load(_fn):
+    """Import one tests_suite file as a submodule of this package."""
+    _name = _fn[:-3]
+    _full = f"{__name__}.{_name}"
+    try:
+        _spec = importlib.util.spec_from_file_location(
+            _full, os.path.join(_SUITE, _fn))
+        _mod = importlib.util.module_from_spec(_spec)
+        sys.modules[_full] = _mod
+        _spec.loader.exec_module(_mod)
+        globals()[_name] = _mod
+    except Exception:
+        pass
+
+
 if os.path.isdir(_SUITE):
-    for _fn in sorted(os.listdir(_SUITE)):
-        if not (_fn.startswith("test_") and _fn.endswith(".py")):
-            continue
-        _name = _fn[:-3]
-        _full = f"{__name__}.{_name}"
-        try:
-            _spec = importlib.util.spec_from_file_location(
-                _full, os.path.join(_SUITE, _fn))
-            _mod = importlib.util.module_from_spec(_spec)
-            sys.modules[_full] = _mod
-            _spec.loader.exec_module(_mod)
-            globals()[_name] = _mod
-        except Exception:
-            pass
+    _files = sorted(os.listdir(_SUITE))
+    # pass 0: helper modules (common.py, …) registered first so that
+    # test_*.py can `from .common import <Base>` — the relative import
+    # resolves through sys.modules.
+    for _fn in _files:
+        if (_fn.endswith(".py") and not _fn.startswith("test_")
+                and _fn != "__init__.py"):
+            _load(_fn)
+    # pass 1: the actual test_*.py modules.
+    for _fn in _files:
+        if _fn.startswith("test_") and _fn.endswith(".py"):
+            _load(_fn)

--- a/connect_freeswitch/tests/__init__.py
+++ b/connect_freeswitch/tests/__init__.py
@@ -22,18 +22,31 @@ _SUITE = os.path.normpath(
                  "tests_suite", "connect_freeswitch", "tests")
 )
 
+def _load(_fn):
+    """Import one tests_suite file as a submodule of this package."""
+    _name = _fn[:-3]
+    _full = f"{__name__}.{_name}"
+    try:
+        _spec = importlib.util.spec_from_file_location(
+            _full, os.path.join(_SUITE, _fn))
+        _mod = importlib.util.module_from_spec(_spec)
+        sys.modules[_full] = _mod
+        _spec.loader.exec_module(_mod)
+        globals()[_name] = _mod
+    except Exception:
+        pass
+
+
 if os.path.isdir(_SUITE):
-    for _fn in sorted(os.listdir(_SUITE)):
-        if not (_fn.startswith("test_") and _fn.endswith(".py")):
-            continue
-        _name = _fn[:-3]
-        _full = f"{__name__}.{_name}"
-        try:
-            _spec = importlib.util.spec_from_file_location(
-                _full, os.path.join(_SUITE, _fn))
-            _mod = importlib.util.module_from_spec(_spec)
-            sys.modules[_full] = _mod
-            _spec.loader.exec_module(_mod)
-            globals()[_name] = _mod
-        except Exception:
-            pass
+    _files = sorted(os.listdir(_SUITE))
+    # pass 0: helper modules (common.py, …) registered first so that
+    # test_*.py can `from .common import <Base>` — the relative import
+    # resolves through sys.modules.
+    for _fn in _files:
+        if (_fn.endswith(".py") and not _fn.startswith("test_")
+                and _fn != "__init__.py"):
+            _load(_fn)
+    # pass 1: the actual test_*.py modules.
+    for _fn in _files:
+        if _fn.startswith("test_") and _fn.endswith(".py"):
+            _load(_fn)

--- a/connect_twilio/tests/__init__.py
+++ b/connect_twilio/tests/__init__.py
@@ -22,18 +22,31 @@ _SUITE = os.path.normpath(
                  "tests_suite", "connect_twilio", "tests")
 )
 
+def _load(_fn):
+    """Import one tests_suite file as a submodule of this package."""
+    _name = _fn[:-3]
+    _full = f"{__name__}.{_name}"
+    try:
+        _spec = importlib.util.spec_from_file_location(
+            _full, os.path.join(_SUITE, _fn))
+        _mod = importlib.util.module_from_spec(_spec)
+        sys.modules[_full] = _mod
+        _spec.loader.exec_module(_mod)
+        globals()[_name] = _mod
+    except Exception:
+        pass
+
+
 if os.path.isdir(_SUITE):
-    for _fn in sorted(os.listdir(_SUITE)):
-        if not (_fn.startswith("test_") and _fn.endswith(".py")):
-            continue
-        _name = _fn[:-3]
-        _full = f"{__name__}.{_name}"
-        try:
-            _spec = importlib.util.spec_from_file_location(
-                _full, os.path.join(_SUITE, _fn))
-            _mod = importlib.util.module_from_spec(_spec)
-            sys.modules[_full] = _mod
-            _spec.loader.exec_module(_mod)
-            globals()[_name] = _mod
-        except Exception:
-            pass
+    _files = sorted(os.listdir(_SUITE))
+    # pass 0: helper modules (common.py, …) registered first so that
+    # test_*.py can `from .common import <Base>` — the relative import
+    # resolves through sys.modules.
+    for _fn in _files:
+        if (_fn.endswith(".py") and not _fn.startswith("test_")
+                and _fn != "__init__.py"):
+            _load(_fn)
+    # pass 1: the actual test_*.py modules.
+    for _fn in _files:
+        if _fn.startswith("test_") and _fn.endswith(".py"):
+            _load(_fn)


### PR DESCRIPTION
## Problem

The 18.0 `tests_suite` branch was already brought to full parity with 19.0 in #42 — it ships `connect/tests/common.py`, `connect_crm/tests/common.py` and the full `test_*.py` set, and the 18.0 gitlink already points at that commit. Every `connect/tests/test_*.py` does `from .common import ConnectTestCommon`.

However, the per-addon test loaders **in the main repo** on 18.0 were never migrated off the old **single-pass** layout. Single-pass loads only `test_*.py` and never registers `common.py`, so the relative `from .common import …` cannot resolve → `connect`'s suite fails to collect on 18.0.

The two-pass loader was introduced on 19.0 (rode along in #111) but the main-repo loader change was not backported here.

## Fix

Copy the **two-pass** loaders from 19.0 verbatim for the three addons that exist on both series — `connect`, `connect_freeswitch`, `connect_twilio`. Pass 0 registers helper modules (`common.py`) into `sys.modules` before pass 1 loads `test_*.py`, so relative imports resolve. The files are now byte-identical to their 19.0 counterparts (they only ever differed in the `_SUITE` path, which is already per-addon correct).

`connect_crm` / `connect_helpdesk` are 19.0-only and have no loader on 18.0, so they're out of scope.

## Notes

- Pure stdlib (`importlib`/`os`/`sys`); no Odoo-version-specific API, so the 19.0 → 18.0 copy is safe.
- No `__manifest__.py` bump: this is test infrastructure and a no-op when `tests_suite` is absent (external uv consumers).
- `tests_suite` gitlink untouched — already at the 18.0 parity commit.