### PR TITLE
fix(connect): make the connect test suite pass standalone

### DIFF
--- a/connect/models/recording.py
+++ b/connect/models/recording.py
@@ -5,6 +5,7 @@ import requests
 from tempfile import NamedTemporaryFile
 from odoo import fields, models, api, release, SUPERUSER_ID
 from odoo.exceptions import ValidationError
+from odoo.tools import config
 from .settings import format_connect_response, debug
 
 logger = logging.getLogger(__name__)
@@ -172,7 +173,11 @@ class Recording(models.Model):
         transcript_calls = self.env['connect.settings'].sudo().get_param('transcript_calls')
         recs = super(Recording, self.with_context(
             mail_create_nosubscribe=True, mail_create_nolog=True)).create(vals_list)
-        self.env.cr.commit()
+        # Persist the recording before the (potentially slow, external)
+        # transcription call. Skipped under test mode, where committing the
+        # cursor mid-transaction is forbidden and would break the rollback.
+        if not config['test_enable']:
+            self.env.cr.commit()
         if transcript_calls:
             for rec in recs:
                 try:

--- a/connect/models/user.py
+++ b/connect/models/user.py
@@ -49,14 +49,18 @@ class User(models.Model):
 
     def manage_group(self, action='add'):
         attribute_name = 'user_ids' if release.version_info[0] >= 19 else 'users'
+        # Adjusting res.groups membership is an internal side-effect of
+        # connect.user CRUD (already gated by connect.group_admin on the
+        # model ACL). Use sudo so a Connect admin who is not also an Odoo
+        # system administrator can still create/remove connect.users.
         if self.user and self.user.has_group('base.group_system') and self.user.has_group('base.group_erp_manager'):
-            group_connect_admin = self.env.ref('connect.group_admin')
+            group_connect_admin = self.env.ref('connect.group_admin').sudo()
             if action == 'add':
                 group_connect_admin.write({attribute_name: [(4, self.user.id)]})
             else:
                 group_connect_admin.with_context(install_mode=True).write({attribute_name: [(3, self.user.id)]})
         elif self.user:
-            group_connect_user = self.env.ref('connect.group_user')
+            group_connect_user = self.env.ref('connect.group_user').sudo()
             if action == 'add':
                 group_connect_user.write({attribute_name: [(4, self.user.id)]})
             else:


### PR DESCRIPTION
`run_odoo_tests connect` was red on 19.0 (empirically **2 failed + 16 errors
of 134**). The connect test suite had only ever run after a `common.py` fix,
which then exposed a chain of latent issues. This branch makes it green
(verified on fs19: **0 failed, 0 errors of 173 tests**, after a `connect`
upgrade so the DB ACLs match the code).

## Product fixes (this repo)
- **`recording.py`**: the unconditional `self.env.cr.commit()` inside
  `create()` broke any test that creates a recording. Guarded with
  `config['test_enable']` (`Registry.in_test_mode()` does not exist on Odoo
  19). Production behaviour is unchanged.
- **`user.py`**: `manage_group()` wrote `res.groups` without `sudo`, so a
  Connect admin who is not also an Odoo system administrator could not
  create/remove `connect.user`s (`AccessError`). The membership change is an
  internal side-effect already gated by `connect.group_admin` on the model
  ACL, so it now runs with `sudo`.

## Test-suite alignment
Carried in the companion tests repo PR (oduist/connect_addons_tests#2, merged)
and picked up via the `tests_suite` gitlink bump. Summary: drop the twilio-only
`username` assumption, assert core `get_user_by_uri`/SIP behaviour, remove
tests for methods deleted in the core/twilio split, fix the `gather_input_type`
default, avoid exten-number collisions with FreeSWITCH demo data, and respect
the "own records only" record rules + admin-only settings.

Also includes a merge of `origin/19.0` (FreeSWITCH fixes #38/#43/#40/#96/#124/#125).