### PR TITLE
[connect_freeswitch] FS Queue fallback routing + mod_fifo auto-reload (ODU-43, ODU-44, ODU-45)

### DIFF
--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.1.10.4',
+    'version': '19.0.1.10.5',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',

--- a/connect_freeswitch/controllers/freeswitch_xml.py
+++ b/connect_freeswitch/controllers/freeswitch_xml.py
@@ -409,6 +409,16 @@ class FreeSwitchXMLController(http.Controller):
                     parts.append(invalid_xml)
                     return ''.join(parts)
 
+        # FS Queue by internal handle: a callflow / IVR fallback transfers to
+        # fs_fifo_<id> when the queue has no user-facing extension (ADR-026).
+        fifo_handle = re.match(r'^fs_fifo_(\d+)$', destination)
+        if fifo_handle:
+            fifo = request.env['connect.fs_fifo'].sudo().browse(
+                int(fifo_handle.group(1)))
+            if fifo.exists():
+                parts.append(fifo.generate_dialplan(params))
+                return ''.join(parts)
+
         # Try exact extension match
         exten = Exten.search([('number', '=', destination)], limit=1)
         if exten:

--- a/connect_freeswitch/controllers/freeswitch_xml.py
+++ b/connect_freeswitch/controllers/freeswitch_xml.py
@@ -482,14 +482,19 @@ class FreeSwitchXMLController(http.Controller):
         return self._not_found()
 
     def _get_sofia_config(self, params):
-        """Serve sofia.conf with gateways from Odoo."""
+        """Serve sofia.conf with the external (TLS-capable) profile and any
+        configured gateways.
+
+        The external profile is rendered **unconditionally** — SIP endpoints
+        register against it and modules can bridge via ``sofia/external/sip:…``
+        even when no gateway records exist. Returning "not found" here when
+        there are no gateways left the profile unable to start on a fresh env
+        (ODU-45). Gateways are rendered into the profile only when present.
+        """
         Gateway = request.env['connect.freeswitch.gateway'].sudo()
         gateways = Gateway.search([('active', '=', True)])
 
-        if not gateways:
-            return self._not_found()
-
-        # Render each gateway individually
+        # Render each gateway individually (empty string if none).
         gateways_xml = '\n'.join(gw.generate_sofia_gateway_xml() for gw in gateways)
 
         sofia_log_level = request.env['connect.settings'].sudo().get_param('freeswitch_sofia_log_level') or '0'

--- a/connect_freeswitch/models/fs_callflow.py
+++ b/connect_freeswitch/models/fs_callflow.py
@@ -70,9 +70,10 @@ class CallFlow(models.Model):
 
         fs_domain = self.env['connect.settings'].sudo().get_param('freeswitch_domain') or '${domain}'
 
-        fifo_number = ''
-        if self.fs_fifo_id and self.fs_fifo_id.exten_number:
-            fifo_number = self.fs_fifo_id.exten_number
+        # Always route via the queue's dialplan target (its extension if
+        # assigned, else the internal fs_fifo_<id> handle) so the fallback
+        # transfer is never silently dropped when the queue has no extension.
+        fifo_number = self.fs_fifo_id._dialplan_target() if self.fs_fifo_id else ''
 
         ring_parts = []
         for user in self.ring_users:
@@ -173,9 +174,10 @@ class CallFlow(models.Model):
                 continue
             bridge_parts.append('user/{}@{}'.format(user_number, fs_domain))
 
-        fifo_number = ''
-        if self.fs_fifo_id and self.fs_fifo_id.exten_number:
-            fifo_number = self.fs_fifo_id.exten_number
+        # Always route via the queue's dialplan target (its extension if
+        # assigned, else the internal fs_fifo_<id> handle) so the fallback
+        # transfer is never silently dropped when the queue has no extension.
+        fifo_number = self.fs_fifo_id._dialplan_target() if self.fs_fifo_id else ''
 
         voicemail_user_number = ''
         if self.voicemail_enabled:
@@ -197,7 +199,7 @@ class CallFlow(models.Model):
 
     def _generate_fifo_fallback_dialplan(self, number):
         """Callflow with only fs_fifo_id: act as a thin transfer-to-queue wrapper."""
-        fifo_number = self.fs_fifo_id.exten_number or str(self.fs_fifo_id.id)
+        fifo_number = self.fs_fifo_id._dialplan_target()
         return (
             '<extension name="callflow_fifo_{id}">'
             '<condition field="destination_number" expression="^{number}$">'

--- a/connect_freeswitch/models/fs_fifo.py
+++ b/connect_freeswitch/models/fs_fifo.py
@@ -50,6 +50,46 @@ class FsFifo(models.Model):
     )
     record_calls = fields.Boolean(default=False)
 
+    # Fields whose change alters the generated fifo.conf (mod_fifo consumers),
+    # so FreeSWITCH must re-read it for the change to take effect (ADR-027).
+    _FIFO_RELOAD_FIELDS = ('member_user_ids', 'member_endpoint_ids', 'max_wait_time')
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        records._trigger_fifo_reload()
+        return records
+
+    def write(self, vals):
+        res = super().write(vals)
+        if any(field in vals for field in self._FIFO_RELOAD_FIELDS):
+            self._trigger_fifo_reload()
+        return res
+
+    def unlink(self):
+        self._trigger_fifo_reload()
+        return super().unlink()
+
+    def _trigger_fifo_reload(self):
+        """Schedule one post-commit ``reload mod_fifo`` so FreeSWITCH re-reads
+        fifo.conf after this queue's members/config change.
+
+        Deferred to after commit because FreeSWITCH re-fetches fifo.conf over
+        xml_curl on a separate connection — it must see committed data. Deduped
+        per transaction via the postcommit callback registry.
+        """
+        callbacks = self.env.cr.postcommit
+        if not callbacks.data.get('connect_fs_fifo_reload'):
+            callbacks.data['connect_fs_fifo_reload'] = True
+            callbacks.add(self._do_fifo_reload)
+
+    def _do_fifo_reload(self):
+        """Best-effort ``reload mod_fifo`` — never break the save if FS is down."""
+        try:
+            self.env['connect.settings'].sudo().freeswitch_api('reload', 'mod_fifo')
+        except Exception:
+            logger.exception('FS Queue: reload mod_fifo failed')
+
     def create_extension(self):
         self.ensure_one()
         return self.env['connect.exten'].create_extension(self, 'fs_fifo')

--- a/connect_freeswitch/models/fs_fifo.py
+++ b/connect_freeswitch/models/fs_fifo.py
@@ -67,10 +67,21 @@ class FsFifo(models.Model):
             return 'user/{}@{}'.format(target, fs_domain)
         return ''
 
+    def _dialplan_target(self):
+        """Destination FreeSWITCH dials to reach this queue.
+
+        The user-facing extension if one is assigned, else the internal
+        ``fs_fifo_<id>`` handle — so the queue is always routable as a
+        callflow/IVR fallback without requiring a numbered extension
+        (the controller resolves ``fs_fifo_<id>`` back to this record).
+        """
+        self.ensure_one()
+        return self.exten_number or 'fs_fifo_%d' % self.id
+
     def generate_dialplan(self, params, exten=None):
         """Generate FreeSWITCH dialplan XML for this FIFO queue."""
         self.ensure_one()
-        number = exten.number if exten else self.exten_number or str(self.id)
+        number = exten.number if exten else self._dialplan_target()
 
         fs_domain = self.env['connect.settings'].sudo().get_param(
             'freeswitch_domain') or '${domain}'

--- a/docs/user/callflows.md
+++ b/docs/user/callflows.md
@@ -61,12 +61,14 @@ The voicemail greeting can be customized per call flow.
 
 When the `connect_freeswitch` module is installed, call flows can route calls into an **FS Queue** — a hold area where the caller hears Music-on-Hold while agents are being rung. The first agent to answer takes the call.
 
-A queue can be used three ways:
+A queue can be used in several ways:
 
-- **Directly as an extension destination** — dial the queue's extension and you enter the queue.
+- **Directly as an extension destination** — give the queue an extension number, then dialing it enters the queue. *(The extension is optional and only needed for direct dialing.)*
 - **As an IVR choice** — any IVR menu option can point to a queue.
 - **As the "no choice" default of an IVR** — if the caller doesn't press anything, the call is transferred into the queue.
 - **As a fallback for a ring group** — if nobody in the ring group answers, the call is moved into the queue before voicemail.
+
+Used as an IVR or ring-group destination, a queue needs **no extension of its own** — it is reached automatically.
 
 ### What the caller experiences
 
@@ -84,3 +86,5 @@ FS Queues are configured under **PBX → FS Queues**. Each queue defines:
 - Music-on-Hold source,
 - whether to announce the caller's position,
 - what to do on timeout (hangup, voicemail, transfer).
+
+Changes to a queue's agents or wait time take effect on the **next call automatically** — no restart or manual step.

--- a/specs/connect_freeswitch.md
+++ b/specs/connect_freeswitch.md
@@ -29,7 +29,7 @@ It ships **three deliverables**:
 Major features:
 - WebRTC via FreeSWITCH `mod_verto` with a phone widget in the Odoo UI;
 - XML-curl directory + dialplan generation driven by Odoo records;
-- mod_fifo-backed call queues with static dialplan consumers (ADR-013);
+- mod_fifo-backed call queues with static dialplan consumers (ADR-013), reachable as a callflow/IVR fallback without a dedicated extension via the `fs_fifo_<id>` handle (ADR-026) and auto-refreshed in FreeSWITCH on change (ADR-027);
 - call parking with BLF subscriptions (ADR-012);
 - gateway / outgoing route management;
 - piper TTS module embedded in the image;
@@ -134,7 +134,7 @@ Beyond firewall, the module contains:
 | `connect.freeswitch.gateway` | SIP gateway records, rendered into pjsip_wizard XML |
 | `connect.freeswitch.outgoing_route` | outbound routing rules |
 | `connect.freeswitch.template` | Jinja2 templates for dialplan / directory XML |
-| `connect.fs_fifo` | mod_fifo queue records (ADR-013) |
+| `connect.fs_fifo` | mod_fifo queue records (ADR-013). `_dialplan_target()` = the queue's extension or, when none, the internal `fs_fifo_<id>` handle that `_route_internal` resolves back to the queue dialplan — so a queue is a routable callflow/IVR fallback without a user-facing extension (ADR-026). `create`/`write(members, max_wait_time)`/`unlink` schedule one post-commit `reload mod_fifo` (`freeswitch_api`) so FreeSWITCH re-reads its consumers (ADR-027) |
 | `connect.freeswitch.parking.slot` | call parking (ADR-012) |
 
 ### Outbound Caller ID resolution

--- a/specs/decisions/026-fs-queue-fallback-auto-extension.md
+++ b/specs/decisions/026-fs-queue-fallback-auto-extension.md
@@ -1,0 +1,112 @@
+# ADR-026: FS Queue fallback in callflows — auto-provision the queue extension
+
+**Status:** Accepted
+**Date:** 2026-06-24
+**Issue:** GitHub [#117](https://github.com/oduist/connect_addons_ng/issues/117), Linear ODU-43
+**Relates to:** [ADR-013](013-freeswitch-fifo-queues.md) (FIFO queues via mod_fifo)
+
+## Context
+
+Issue #117 reports that the **"Fallback Queue"** on a callflow does nothing: when a
+ring group times out or nobody answers, the caller is **dropped** instead of being
+routed into the FS Queue. The issue diagnoses this as *"no queue model exists
+anywhere"* and asks to build a new `connect.freeswitch.queue` model on
+`mod_callcenter`.
+
+That diagnosis is **wrong**. Investigation (reproduced on a clean Odoo 19
+environment, `19.0-fs-queue`) establishes:
+
+- The FS Queue feature **already exists** (ADR-013): model `connect.fs_fifo`,
+  dialplan template `dialplan_fs_fifo`, static consumers served via
+  `fifo.conf.xml`, and the `connect.callflow.fs_fifo_id` ("FS Queue") field.
+  `mod_fifo` landed 2026-04-22 (PR #30); #117 was filed **2026-06-11**, i.e.
+  against code that already has the queue.
+- The ring-group fallback **is** wired: `dialplan_ring_group` emits
+  `<action application="transfer" data="{{ fifo_number }} XML default"/>` after a
+  failed bridge — **but only inside `{% if fifo_number %}`**.
+
+### Root cause (reproduced)
+
+`fifo_number` is the queue's `exten_number`: a stored related field on
+`connect.fs_fifo.exten` (the queue's `connect.exten`). A queue has **no extension**
+until an admin manually fills in the extension form — the "Extension" stat button's
+`create_extension()` (`connect/models/exten.py:117`) only returns an
+`ir.actions.act_window` that opens that form; **it creates nothing by itself**.
+
+When a queue without an extension is chosen as a callflow fallback:
+
+- `_generate_ring_group_dialplan` / `_generate_ivr_dialplan` compute
+  `fifo_number = ''`, so the `{% if fifo_number %}` transfer block is **silently
+  omitted** → the caller is dropped after the ring timeout.
+- The standalone `_generate_fifo_fallback_dialplan` uses
+  `exten_number or str(id)`, but that `str(id)` fallback is **illusory**: the
+  FreeSWITCH XML dialplan controller resolves transfer targets only by
+  `connect.exten.number` (`freeswitch_xml.py:413` exact, `:422` regex). With no
+  `connect.exten`, `transfer <id>` matches nothing. There is **no** "fifo by bare
+  id" route.
+
+**Conclusion:** a queue is reachable from the dialplan **only if it has a
+provisioned `connect.exten`**. Reproduction: a ring-group callflow whose fallback
+queue has no extension generates an extension with **no `bridge` and no
+`transfer`** — only variable-setting actions, then an implicit hangup. Exactly the
+symptom in #117.
+
+So #117 is a **bug in the existing mod_fifo feature**, not a missing feature.
+Rebuilding on `mod_callcenter` would duplicate working code and reverse ADR-013's
+deliberate choice.
+
+## Options
+
+1. **Build `connect.freeswitch.queue` on `mod_callcenter`** (the issue's literal
+   "Expected Fix"). Rejected: duplicates the mod_fifo feature, large effort,
+   reverses ADR-013; no product need for ACD agent-state/tiers right now.
+2. **Emit the transfer unconditionally with an `or str(id)` fallback** in the
+   ring-group/IVR templates, mirroring the standalone path. Rejected on its own:
+   routing is by `exten.number` only, so `str(id)` transfers to a dead target.
+3. **Auto-provision an extension for the queue on create** so every queue is
+   routable. Fixes the root cause at the source.
+4. **Validate** — raise a clear error when a queue without an extension is used as
+   a destination. Removes the silent failure but keeps the manual extension step.
+
+5. **Route the queue by an internal handle `fs_fifo_<id>`** — make the queue reachable
+   from the dialplan without any user-facing extension; the callflow always transfers to
+   that handle. **Chosen.**
+
+## Decision
+
+Adopt **(5): route the queue by the internal handle `fs_fifo_<id>`.**
+
+> Auto-provisioning (3+4) was initially chosen but then rejected by the deployment owner:
+> it pollutes the numeric extension namespace and is "magic". Option 5 needs no extension,
+> no auto-numbering, and no migration, and it also repairs the standalone path.
+
+- New helper `connect.fs_fifo._dialplan_target()` → `self.exten_number or 'fs_fifo_%d' % self.id`.
+  A user-facing extension stays **optional** (only for direct dialing) and takes precedence.
+- `connect.fs_fifo.generate_dialplan` self-names by the handle when it has no exten:
+  `number = exten.number if exten else self._dialplan_target()`, so the rendered condition
+  `^fs_fifo_<id>$` matches the transferred destination.
+- The dialplan controller `_route_internal` gains a branch: a destination matching
+  `^fs_fifo_(\d+)$` resolves the queue and returns `fifo.generate_dialplan(params)` —
+  mirroring the existing synthetic-destination branches (`cf_call_*`, `cf_invalid_*`).
+- The three callflow paths (`_generate_ring_group_dialplan`, `_generate_ivr_dialplan`,
+  `_generate_fifo_fallback_dialplan`) compute `fifo_number = fs_fifo_id._dialplan_target()`
+  — always non-empty when a fallback queue is set, so the `{% if fifo_number %}` transfer
+  block is always emitted. This also fixes the previously **dead `str(id)`** in the standalone
+  path (which never routed, because the controller only matched by `connect.exten.number`).
+
+No silent omission, no auto-numbering, no manual-extension requirement, **no migration**.
+`mod_fifo` and ADR-013 stand; no FreeSWITCH image rebuild (nothing under `deploy/` changes).
+
+## Consequences
+
+- A queue is routable as a callflow/IVR fallback the moment it exists — no extension needed.
+- Assigning a user-facing extension to a queue remains supported (direct dialing) and wins
+  in `_dialplan_target()`.
+- **Tests (TDD):** (a) a ring-group callflow with an extension-less fallback queue renders a
+  `transfer … fs_fifo_<id>`; (b) the controller routes `fs_fifo_<id>` to the queue dialplan.
+- **Docs/specs:** document the `fs_fifo_<id>` internal handle and that a queue extension is
+  optional.
+- Issue #117 reclassified from "feature request (mod_callcenter)" to "bug fix in mod_fifo
+  fallback routing".
+- Separate runtime bug found while verifying live (ODU-44): mod_fifo isn't re-read after a
+  queue's members change, so agents aren't rung until `reload mod_fifo`. Tracked separately.

--- a/specs/decisions/027-fs-queue-reload-mod-fifo.md
+++ b/specs/decisions/027-fs-queue-reload-mod-fifo.md
@@ -1,0 +1,38 @@
+# ADR-027: Refresh mod_fifo when an FS Queue changes
+
+**Status:** Accepted
+**Date:** 2026-06-25
+**Issue:** Linear ODU-44
+**Relates to:** [ADR-013](013-freeswitch-fifo-queues.md) (mod_fifo), [ADR-026](026-fs-queue-fallback-auto-extension.md)
+
+## Context
+
+mod_fifo loads its outbound `<member>` consumers from `fifo.conf.xml` (served by
+`connect_freeswitch` via xml_curl) **only at module (re)load**. When a queue's members
+or `max_wait_time` change in Odoo, the generated `fifo.conf` changes but FreeSWITCH keeps
+the **stale** list — so `fifo list` shows `outbound_per_cycle=0`, mod_fifo never originates
+the agent, and the caller waits in silence. Reproduced live (ODU-44): a member added in
+Odoo only started ringing after a manual `fs_cli -x "reload mod_fifo"`.
+
+## Decision
+
+When a `connect.fs_fifo` is created/written (members/`max_wait_time`) or unlinked, Odoo
+issues `freeswitch_api('reload', 'mod_fifo')` (verified: a single call re-reads XML via
+xml_curl, no separate `reloadxml` needed).
+
+**Timing — after commit.** The reload is scheduled on `cr.postcommit`, not run inline:
+FreeSWITCH re-fetches `fifo.conf` over xml_curl on a **separate** connection, so it must run
+**after** Odoo commits or it would read the pre-change data. The callback is **deduped per
+transaction** (one reload regardless of how many queues/writes), and **best-effort**
+(`try/except` + log) so a save never fails because FreeSWITCH is unreachable.
+
+Only fifo.conf-affecting fields trigger it (`member_user_ids`, `member_endpoint_ids`,
+`max_wait_time`). Per-call dialplan fields (MoH, timeout action, recording) are fetched fresh
+via xml_curl on every call and need no reload.
+
+## Consequences
+
+- Editing a queue's agents in the UI takes effect on the next call with no manual step.
+- A brief module reload on each queue change; negligible at human edit rates, and deduped.
+- No schema change, no migration. ODU-43 (reachability) + ODU-44 (this) together make the
+  FS Queue work end-to-end.


### PR DESCRIPTION
## Summary

Makes the **FS Queue** (`mod_fifo`) feature work end-to-end as a callflow/IVR fallback, plus a Sofia profile fix. Four focused commits on `connect_freeswitch`.

### ODU-43 / #117 — Route FS Queue fallback via the `fs_fifo_<id>` handle
A queue set as a callflow "Fallback Queue" did nothing: callers were dropped instead of being queued, because routing happened only through the queue's optional `connect.exten` number, which is not auto-created.

- New `connect.fs_fifo._dialplan_target()` → `exten_number or 'fs_fifo_<id>'`; a user-facing extension stays optional and takes precedence.
- `generate_dialplan` self-names by the handle (`^fs_fifo_<id>$`) when there is no extension.
- The XML dialplan controller resolves a `^fs_fifo_(\d+)$` destination back to the queue (mirrors the existing `cf_call_*` / `cf_invalid_*` synthetic destinations).
- Ring-group / IVR / standalone callflow paths now always emit the fallback `transfer`, fixing the previously dead `str(id)` route.

No numbered-extension requirement, no auto-numbering, **no migration**. See ADR-026.

### ODU-44 — Reload `mod_fifo` when an FS Queue changes
`mod_fifo` reads its outbound `<member>` consumers from `fifo.conf` only at module (re)load, so editing a queue's agents in Odoo left FreeSWITCH with a stale list (`outbound_per_cycle=0`) and the agent was never rung.

- On create / write (`member_user_ids`, `member_endpoint_ids`, `max_wait_time`) / unlink, Odoo issues `freeswitch_api('reload', 'mod_fifo')`.
- Scheduled on `cr.postcommit` (FreeSWITCH re-fetches over xml_curl on a separate connection → must see committed data), deduped per transaction, best-effort so a save never fails when FreeSWITCH is down.

See ADR-027.

### ODU-45 — Always serve the Sofia external profile
Serve the `sofia` external profile from the XML config controller even when no gateways are configured, so the profile is always available.

## Docs / specs
- ADR-026 (fallback via `fs_fifo_<id>` handle) and ADR-027 (reload `mod_fifo`).
- `specs/connect_freeswitch.md`, `docs/user/callflows.md` updated.

## Test plan
- Ring-group callflow with an extension-less fallback queue renders `transfer … fs_fifo_<id>`.
- Controller routes `fs_fifo_<id>` to the queue dialplan.
- Editing a queue's agents takes effect on the next call without a manual `reload mod_fifo`.
