### PR TITLE
fix(freeswitch): serve sofia external profile with no gateways (ODU-45)

### DIFF
--- a/connect_freeswitch/__manifest__.py
+++ b/connect_freeswitch/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect FreeSWITCH',
-    'version': '19.0.2.0.0',
+    'version': '19.0.2.0.1',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'FreeSWITCH integration for Oduist Connect',

--- a/connect_freeswitch/controllers/freeswitch_xml.py
+++ b/connect_freeswitch/controllers/freeswitch_xml.py
@@ -492,14 +492,19 @@ class FreeSwitchXMLController(http.Controller):
         return self._not_found()
 
     def _get_sofia_config(self, params):
-        """Serve sofia.conf with gateways from Odoo."""
+        """Serve sofia.conf with the external (TLS-capable) profile and any
+        configured gateways.
+
+        The external profile is rendered **unconditionally** — SIP endpoints
+        register against it and modules can bridge via ``sofia/external/sip:…``
+        even when no gateway records exist. Returning "not found" here when
+        there are no gateways left the profile unable to start on a fresh env
+        (ODU-45). Gateways are rendered into the profile only when present.
+        """
         Gateway = request.env['connect.freeswitch.gateway'].sudo()
         gateways = Gateway.search([('active', '=', True)])
 
-        if not gateways:
-            return self._not_found()
-
-        # Render each gateway individually
+        # Render each gateway individually (empty string if none).
         gateways_xml = '\n'.join(gw.generate_sofia_gateway_xml() for gw in gateways)
 
         sofia_log_level = request.env['connect.settings'].sudo().get_param('freeswitch_sofia_log_level') or '0'

--- a/specs/decisions/028-freeswitch-first-gateway-profile-start.md
+++ b/specs/decisions/028-freeswitch-first-gateway-profile-start.md
@@ -29,8 +29,10 @@ There are **two** root causes, and a correct fix must close both:
    But `_reload_sofia_profile()` ran *inside* `create()`, **before** the
    transaction committed. Under PostgreSQL `READ COMMITTED`, the xml_curl
    request cannot see the uncommitted gateway, so `_get_sofia_config` finds no
-   active gateways and returns `_not_found()` — FreeSWITCH gets an empty config
-   and the profile starts without the gateway (or not at all). This is why the
+   active gateways. (At the time of this ADR that returned `_not_found()`;
+   **ADR-034** later dropped that gate so the `external` profile is now served
+   unconditionally — but the visibility race for the *gateway* still requires
+   the post-commit deferral decided here.) This is why the
    *manual* `start` works (the row is committed by then) but a synchronous
    `start` issued from `create()` would not reliably help. The same race
    applies to `_reload_acl()`, whose `gateways` ACL is also served via

--- a/specs/decisions/034-freeswitch-sofia-external-profile-unconditional.md
+++ b/specs/decisions/034-freeswitch-sofia-external-profile-unconditional.md
@@ -1,0 +1,70 @@
+# ADR-034: Always serve the sofia `external` profile, even with no gateways
+
+## Status
+Accepted
+
+## Context
+
+The `external` sofia profile is served on demand from Odoo via `mod_xml_curl`
+(`controllers/freeswitch_xml.py::_get_sofia_config`) — the static
+`autoload_configs/sofia.conf.xml` ships an empty `<profiles/>`. SIP endpoints
+register against `external` and modules bridge outbound legs via
+`sofia/external/sip:…`, so the profile must exist independently of whether any
+outbound **gateway** (SIP trunk) records exist.
+
+`_get_sofia_config` gated the whole response on gateways:
+
+```python
+if not gateways:
+    return self._not_found()
+```
+
+On a fresh env with no gateway records, Odoo answered the `sofia.conf` xml_curl
+request with `<result status="not found"/>`. FreeSWITCH got **no** sofia
+configuration at all, so the `external` profile could not start
+(`sofia status` → `0 profiles`, `sofia profile external start` →
+`Failure starting external`). No SIP registration was possible; only the Verto
+(WebRTC) profile, which is served separately, kept working. This surfaced on a
+fresh deployment (ODU-45).
+
+The gate was a code regression on `19.0`: the sibling `19.0-twilio-fs-compat`
+branch already rendered the profile unconditionally. The template
+(`data/fs_templates.xml::config_sofia`) always renders the full
+`<profile name="external">` and injects `{{ gateways_xml }}` (empty when there
+are none), so the gate was the only thing suppressing a valid config.
+
+## Decision
+
+Drop the `if not gateways: return self._not_found()` gate. `_get_sofia_config`
+now **always** renders the `external` profile; gateways are joined into the
+profile only when present (empty string otherwise). A fresh env therefore serves
+a valid `sofia.conf` and the `external` profile starts and accepts
+registrations without any gateway, DID, or firewall record.
+
+This does **not** revert ADR-028: the post-commit deferral of
+`_reload_sofia_profile()` / `_reload_acl()` is still required so that a
+newly-created gateway is committed (and thus visible to the separate xml_curl
+cursor) before FreeSWITCH re-fetches the profile. ADR-034 only removes the
+"empty config when zero gateways" failure mode; ADR-028 continues to govern the
+reload timing and the `start`-vs-`restart` status check.
+
+## Alternatives considered
+
+- **Auto-start `external` from static config at FreeSWITCH boot.** Rejected for
+  the same reason as in ADR-028: the profile config is intentionally dynamic
+  (served from Odoo) and booting it statically races Odoo availability and
+  duplicates the xml_curl-driven model.
+
+- **Keep the gate but return a gateway-less profile only when endpoints/DIDs
+  exist.** Rejected: the `external` profile is the SIP-registration surface and
+  must be up on a bare env before any endpoint is configured; conditioning it on
+  other records reintroduces the same class of "profile absent on fresh env"
+  bug.
+
+## Cross-branch backport
+
+Per `CLAUDE.md` versioning rules the same one-line fix ports to `18.0` with the
+aligned tail version. `18.0` may already carry the fix (like
+`19.0-twilio-fs-compat`) — verify before porting. No schema change, so no
+migration script is required. Regression coverage lives in
+`tests_suite/connect_freeswitch/tests/test_sofia_config.py`.


### PR DESCRIPTION
## Problem (ODU-45)

On a freshly provisioned env with no `connect.freeswitch.gateway` records, FreeSWITCH could not start the sofia `external` profile:

- `sofia status` → `0 profiles`
- `sofia profile external start` → `Failure starting external`

Only the Verto (WebRTC) profile kept working, so browser calls were fine but **all SIP registration / trunks were dead**.

## Root cause

A code regression on `19.0`. `_get_sofia_config` (`connect_freeswitch/controllers/freeswitch_xml.py`) gated the entire `sofia.conf` xml_curl response on gateways:

```python
if not gateways:
    return self._not_found()
```

With zero gateways Odoo answered `<result status="not found"/>`, so FreeSWITCH got **no** sofia config and the external profile never started. The `config_sofia` template already renders the full `<profile name="external">` unconditionally — the gate was the only thing suppressing a valid config. The sibling `19.0-twilio-fs-compat` branch already rendered it unconditionally; the fix was never ported to `19.0`.

## Fix

Drop the gate — always render the `external` profile; gateways are injected only when present. Does **not** revert ADR-028: the post-commit reload deferral is still required for gateway visibility.

## Verification (fresh oduflow env, no gateways)

- xml_curl `sofia.conf` now serves `<profile name="external">` instead of `not found`.
- New regression test `tests_suite/connect_freeswitch/tests/test_sofia_config.py` — `0 failed, 0 error(s) of 2 tests`:
  - `test_external_profile_served_with_no_gateways`
  - `test_gateway_injected_when_present`

## Docs / specs

- ADR-034 records the decision; ADR-028 cross-references it.
- `connect_freeswitch` `19.0.2.0.0 → 19.0.2.0.1`.
- `tests_suite` gitlink advanced to the pushed regression test (committed directly to the `19.0` series branch per repo policy).

## Follow-up

- Backport to `18.0` (may already carry the fix, like `19.0-twilio-fs-compat` — verify first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)