### PR TITLE
Add Telnyx AI voice assistants

### DIFF
--- a/connect_telnyx/__manifest__.py
+++ b/connect_telnyx/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Oduist Connect Telnyx',
-    'version': '19.0.1.0.0',
+    'version': '19.0.1.1.0',
     'author': 'Oduist',
     'category': 'Phone',
     'summary': 'Telnyx integration for Oduist Connect',
@@ -12,6 +12,7 @@
         'security/access_rules.xml',
         'views/menu.xml',
         'views/settings_views.xml',
+        'views/ai_assistant_views.xml',
         'views/texml_views.xml',
         'views/domain_views.xml',
         'views/user_views.xml',
@@ -28,6 +29,7 @@
         'wizard/sms_composer_views.xml',
         'wizard/whatsapp_composer_views.xml',
         'wizard/rcs_composer_views.xml',
+        'wizard/ai_call_wizard_views.xml',
         'data/texml.xml',
         'data/ir_cron.xml',
     ],

--- a/connect_telnyx/controllers/telnyx_webhooks.py
+++ b/connect_telnyx/controllers/telnyx_webhooks.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 import logging
+import hmac
 
 from odoo.http import request, Controller, route
 from telnyx.lib.webhook_verification import (
@@ -9,6 +10,8 @@ from telnyx.lib.webhook_verification import (
 )
 
 logger = logging.getLogger(__name__)
+
+MAX_AI_WEBHOOK_BYTES = 64 * 1024
 
 
 class ConnectTelnyxController(Controller):
@@ -124,3 +127,110 @@ class ConnectTelnyxController(Controller):
         message = request.env['connect.message'].with_user(request.env.ref("connect.user_connect_webhook"))
         res = message.telnyx_receive(event)
         return f'{res}'
+
+    @staticmethod
+    def _ai_json_body():
+        raw = request.httprequest.get_data() or b'{}'
+        if len(raw) > MAX_AI_WEBHOOK_BYTES:
+            return None
+        try:
+            value = json.loads(raw)
+        except (TypeError, ValueError):
+            return None
+        return value if isinstance(value, dict) else None
+
+    @route(
+        '/telnyx/webhook/assistant/<int:assistant_id>/variables',
+        methods=['POST'], type='http', auth='public', csrf=False,
+    )
+    def assistant_variables_webhook(self, assistant_id, **kw):
+        if not self.check_signature():
+            return request.make_json_response(
+                {'error': 'invalid_signature'}, status=403)
+        event = self._ai_json_body()
+        if event is None:
+            return request.make_json_response(
+                {'error': 'invalid_json'}, status=400)
+        assistant = request.env[
+            'connect.telnyx.ai_assistant'
+        ].with_user(request.env.ref('connect.user_connect_webhook')).browse(
+            assistant_id)
+        if not assistant.exists():
+            return request.make_json_response(
+                {'error': 'assistant_not_found'}, status=404)
+        payload = (event.get('data') or {}).get('payload') or event.get(
+            'payload') or {}
+        if payload.get('assistant_id') not in (None, assistant.sid):
+            return request.make_json_response(
+                {'error': 'assistant_mismatch'}, status=403)
+        call = request.env['connect.call'].with_user(
+            request.env.ref('connect.user_connect_webhook')
+        ).telnyx_link_ai_conversation(payload)
+        phone = payload.get('telnyx_end_user_target')
+        partner = request.env['res.partner'].sudo().get_partner_by_number(
+            phone) if phone else request.env['res.partner']
+        if call and partner and not call.partner:
+            call.sudo().partner = partner
+        result = {
+            'dynamic_variables': assistant._partner_values(partner),
+            'conversation': {
+                'metadata': {
+                    'odoo_assistant_id': str(assistant.id),
+                    'odoo_partner_id': str(partner.id) if partner else '',
+                }
+            },
+        }
+        if assistant.memory_enabled and phone:
+            result['memory'] = {
+                'conversation_query': (
+                    'metadata->telnyx_end_user_target=eq.{}&limit=5'
+                    '&order=last_message_at.desc'.format(phone)
+                )
+            }
+        return request.make_json_response(result)
+
+    @route(
+        '/telnyx/webhook/assistant/<int:assistant_id>/tool/<string:tool_name>',
+        methods=['POST'], type='http', auth='public', csrf=False,
+    )
+    def assistant_tool_webhook(self, assistant_id, tool_name, **kw):
+        assistant = request.env['connect.telnyx.ai_assistant'].sudo().browse(
+            assistant_id)
+        supplied = request.httprequest.headers.get(
+            'X-Odoo-Telnyx-Token', '')
+        expected = assistant.tool_token or '' if assistant.exists() else ''
+        if not expected or not hmac.compare_digest(supplied, expected):
+            return request.make_json_response(
+                {'error': 'unauthorized'}, status=403)
+        payload = self._ai_json_body()
+        if payload is None:
+            return request.make_json_response(
+                {'error': 'invalid_json'}, status=400)
+        try:
+            result = assistant.execute_tool(
+                tool_name, payload,
+                call_control_id=request.httprequest.headers.get(
+                    'x-telnyx-call-control-id'),
+            )
+        except Exception as exc:
+            logger.warning('Telnyx AI tool %s failed: %s', tool_name, exc)
+            return request.make_json_response(
+                {'ok': False, 'error': str(exc)}, status=400)
+        return request.make_json_response(result)
+
+    @route(
+        '/telnyx/webhook/assistant/insights',
+        methods=['POST'], type='http', auth='public', csrf=False,
+    )
+    def assistant_insights_webhook(self, **kw):
+        if not self.check_signature():
+            return request.make_json_response(
+                {'error': 'invalid_signature'}, status=403)
+        payload = self._ai_json_body()
+        if payload is None:
+            return request.make_json_response(
+                {'error': 'invalid_json'}, status=400)
+        request.env['connect.call'].with_user(
+            request.env.ref('connect.user_connect_webhook')
+        ).telnyx_apply_ai_insights(payload)
+        return request.make_json_response({'ok': True})

--- a/connect_telnyx/data/ir_cron.xml
+++ b/connect_telnyx/data/ir_cron.xml
@@ -10,5 +10,14 @@
             <field name="state">code</field>
             <field name="active">True</field>
         </record>
+        <record id="telnyx_sync_ai_conversations" model="ir.cron">
+            <field name="name">Sync Telnyx AI Conversations</field>
+            <field name="interval_number">5</field>
+            <field name="interval_type">minutes</field>
+            <field name="model_id" ref="connect.model_connect_call"/>
+            <field name="code">model.telnyx_sync_ai_conversations_batch()</field>
+            <field name="state">code</field>
+            <field name="active">True</field>
+        </record>
     </data>
 </odoo>

--- a/connect_telnyx/models/__init__.py
+++ b/connect_telnyx/models/__init__.py
@@ -16,3 +16,4 @@ from . import whatsapp_sender
 from . import whatsapp_template
 from . import rcs_agent
 from . import message_configuration
+from . import ai_assistant

--- a/connect_telnyx/models/ai_assistant.py
+++ b/connect_telnyx/models/ai_assistant.py
@@ -354,7 +354,8 @@ class TelnyxAIAssistant(models.Model):
             if not sid:
                 continue
             rec = self.search([("sid", "=", sid)], limit=1)
-            vals = self._remote_values(item, imported=not bool(rec))
+            vals = self._remote_values(
+                item, imported=rec.imported if rec else True)
             if rec:
                 rec.with_context(skip_telnyx_ai_sync=True).write(vals)
             else:

--- a/connect_telnyx/models/ai_assistant.py
+++ b/connect_telnyx/models/ai_assistant.py
@@ -1,0 +1,489 @@
+# -*- coding: utf-8 -*-
+import secrets
+from urllib.parse import urljoin
+
+from markupsafe import escape
+
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+from odoo.models import Constraint
+
+REMOTE_FIELDS = {
+    "name", "description", "instructions", "greeting", "model",
+    "voice", "voice_speed", "transcription_model",
+    "transcription_language", "time_limit_secs", "record_calls",
+    "memory_enabled", "enable_contact_tools", "enable_crm_tools",
+    "enable_helpdesk_tools", "active",
+}
+
+
+class TelnyxAIAssistant(models.Model):
+    _name = "connect.telnyx.ai_assistant"
+    _description = "Telnyx AI Assistant"
+    _order = "name"
+
+    sid = fields.Char(string="Telnyx ID", readonly=True, copy=False, index=True)
+    version_id = fields.Char(readonly=True, copy=False)
+    name = fields.Char(required=True)
+    description = fields.Text()
+    instructions = fields.Text(
+        required=True,
+        default=(
+            "You are a helpful voice assistant. Be concise, transparent, "
+            "and use the available Odoo tools only when they are needed."
+        ),
+    )
+    greeting = fields.Text(default="Hello! How can I help you today?")
+    model = fields.Char(help="Leave empty to use the Telnyx default model.")
+    voice = fields.Char(help="Telnyx voice identifier.")
+    voice_speed = fields.Float(default=1.0)
+    transcription_model = fields.Char(
+        help="For example deepgram/nova-3. Leave empty for Telnyx default."
+    )
+    transcription_language = fields.Char()
+    time_limit_secs = fields.Integer(default=1800, required=True)
+    record_calls = fields.Boolean(default=False)
+    memory_enabled = fields.Boolean(default=False)
+    enable_contact_tools = fields.Boolean(default=True)
+    enable_crm_tools = fields.Boolean(default=False)
+    enable_helpdesk_tools = fields.Boolean(default=False)
+    active = fields.Boolean(default=True)
+    imported = fields.Boolean(readonly=True, copy=False)
+    last_sync_at = fields.Datetime(readonly=True, copy=False)
+    tool_token = fields.Char(
+        readonly=True, copy=False,
+        groups="connect.group_admin,base.group_erp_manager",
+    )
+
+    _sid_unique = Constraint(
+        "UNIQUE(sid)", "A Telnyx AI Assistant ID must be unique."
+    )
+
+    @api.constrains("time_limit_secs")
+    def _check_time_limit(self):
+        for rec in self:
+            if rec.time_limit_secs < 30 or rec.time_limit_secs > 14400:
+                raise ValidationError(
+                    "The AI assistant call limit must be between 30 and "
+                    "14,400 seconds."
+                )
+
+    @api.model
+    def _unwrap(self, response):
+        if isinstance(response, dict) and "data" in response:
+            return response["data"]
+        return response
+
+    def _variables_url(self):
+        self.ensure_one()
+        api_url = self.env["connect.settings"].sudo().get_param("api_url")
+        return urljoin(
+            api_url, "telnyx/webhook/assistant/{}/variables".format(self.id)
+        )
+
+    def _tool_url(self, tool_name):
+        self.ensure_one()
+        api_url = self.env["connect.settings"].sudo().get_param("api_url")
+        return urljoin(
+            api_url,
+            "telnyx/webhook/assistant/{}/tool/{}".format(self.id, tool_name),
+        )
+
+    def _webhook_tool(self, name, description, properties, required=None):
+        self.ensure_one()
+        return {
+            "type": "webhook",
+            "webhook": {
+                "name": name,
+                "description": description,
+                "url": self._tool_url(name),
+                "method": "POST",
+                "headers": [
+                    {
+                        "name": "X-Odoo-Telnyx-Token",
+                        "value": self.sudo().tool_token,
+                    }
+                ],
+                "body_parameters": {
+                    "type": "object",
+                    "properties": properties,
+                    "required": required or [],
+                    "additionalProperties": False,
+                },
+                "timeout_ms": 5000,
+            },
+        }
+
+    def _tool_payload(self):
+        self.ensure_one()
+        tools = [{"type": "hangup"}]
+        if self.enable_contact_tools:
+            tools.extend([
+                self._webhook_tool(
+                    "lookup_contact",
+                    "Find the Odoo contact for the caller or a supplied phone.",
+                    {
+                        "phone": {
+                            "type": "string",
+                            "description": "Phone number; omit for current caller.",
+                        }
+                    },
+                ),
+                self._webhook_tool(
+                    "add_contact_note",
+                    "Add an internal note to the current Odoo contact.",
+                    {
+                        "phone": {"type": "string"},
+                        "note": {
+                            "type": "string",
+                            "description": "Short factual note from the call.",
+                        },
+                    },
+                    ["note"],
+                ),
+            ])
+        if self.enable_crm_tools and "crm.lead" in self.env:
+            tools.append(self._webhook_tool(
+                "upsert_crm_lead",
+                "Create or update the open CRM lead for this caller.",
+                {
+                    "phone": {"type": "string"},
+                    "title": {"type": "string"},
+                    "note": {"type": "string"},
+                },
+                ["title", "note"],
+            ))
+        if self.enable_helpdesk_tools and "helpdesk.ticket" in self.env:
+            tools.append(self._webhook_tool(
+                "upsert_helpdesk_ticket",
+                "Create or update the open Helpdesk ticket for this caller.",
+                {
+                    "phone": {"type": "string"},
+                    "title": {"type": "string"},
+                    "note": {"type": "string"},
+                },
+                ["title", "note"],
+            ))
+        return tools
+
+    def _remote_payload(self):
+        self.ensure_one()
+        payload = {
+            "name": self.name,
+            "description": self.description or "",
+            "instructions": self.instructions,
+            "greeting": self.greeting or "",
+            "enabled_features": ["telephony"],
+            "dynamic_variables_webhook_url": self._variables_url(),
+            "dynamic_variables_webhook_timeout_ms": 1500,
+            "tools": self._tool_payload(),
+            "telephony_settings": {
+                "time_limit_secs": self.time_limit_secs,
+                "recording_settings": {
+                    "enabled": self.record_calls,
+                    "channels": "dual",
+                    "format": "mp3",
+                    "stop_on_conversation_end": True,
+                },
+            },
+            "privacy_settings": {"data_retention": True},
+        }
+        if self.model:
+            payload["model"] = self.model
+        if self.voice:
+            payload["voice_settings"] = {
+                "voice": self.voice,
+                "voice_speed": self.voice_speed,
+            }
+        transcription = {}
+        if self.transcription_model:
+            transcription["model"] = self.transcription_model
+        if self.transcription_language:
+            transcription["language"] = self.transcription_language
+        if transcription:
+            payload["transcription"] = transcription
+        group_id = self.env["connect.settings"].sudo().get_param(
+            "telnyx_ai_summary_group_id"
+        )
+        if group_id:
+            payload["insight_settings"] = {"insight_group_id": group_id}
+        return payload
+
+    @api.model
+    def _remote_values(self, data, imported=False):
+        voice_settings = data.get("voice_settings") or {}
+        transcription = data.get("transcription") or {}
+        telephony = data.get("telephony_settings") or {}
+        recording = telephony.get("recording_settings") or {}
+        vals = {
+            "sid": data.get("id"),
+            "version_id": data.get("version_id"),
+            "name": data.get("name") or "Telnyx AI Assistant",
+            "description": data.get("description") or "",
+            "instructions": data.get("instructions") or "Be helpful.",
+            "greeting": data.get("greeting") or "",
+            "model": data.get("model") or "",
+            "voice": voice_settings.get("voice") or "",
+            "voice_speed": (
+                voice_settings.get("voice_speed")
+                or voice_settings.get("speed") or 1.0
+            ),
+            "transcription_model": transcription.get("model") or "",
+            "transcription_language": transcription.get("language") or "",
+            "time_limit_secs": telephony.get("time_limit_secs") or 1800,
+            "record_calls": bool(recording.get("enabled")),
+            "imported": imported,
+            "last_sync_at": fields.Datetime.now(),
+        }
+        return vals
+
+    def _apply_remote_data(self, data):
+        self.ensure_one()
+        self.with_context(skip_telnyx_ai_sync=True).write(
+            self._remote_values(data, imported=self.imported)
+        )
+
+    def _create_remote(self):
+        self.ensure_one()
+        self._ensure_summary_group()
+        data = self._unwrap(
+            self.env["connect.settings"].telnyx_api_request(
+                "POST", "ai/assistants", payload=self._remote_payload()
+            )
+        )
+        self._apply_remote_data(data)
+
+    def _update_remote(self):
+        self.ensure_one()
+        if not self.sid:
+            return self._create_remote()
+        data = self._unwrap(
+            self.env["connect.settings"].telnyx_api_request(
+                "POST", "ai/assistants/{}".format(self.sid),
+                payload=self._remote_payload(),
+            )
+        )
+        self._apply_remote_data(data)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        vals_list = [dict(vals) for vals in vals_list]
+        for vals in vals_list:
+            vals.setdefault("tool_token", secrets.token_urlsafe(32))
+        records = super().create(vals_list)
+        if (self.env.context.get("install_mode")
+                or self.env.context.get("skip_telnyx_ai_sync")):
+            return records
+        for rec in records:
+            rec._create_remote()
+        return records
+
+    def write(self, vals):
+        res = super().write(vals)
+        if (self.env.context.get("skip_telnyx_ai_sync")
+                or not REMOTE_FIELDS.intersection(vals)
+                or not self.env["connect.settings"].sudo().get_param(
+                    "telnyx_auto_sync"
+                )):
+            return res
+        for rec in self:
+            rec._update_remote()
+        return res
+
+    def unlink(self):
+        if (not self.env.context.get("skip_telnyx_ai_sync")
+                and self.env["connect.settings"].sudo().get_param(
+                    "telnyx_auto_sync"
+                )):
+            for rec in self.filtered("sid"):
+                self.env["connect.settings"].telnyx_api_request(
+                    "DELETE", "ai/assistants/{}".format(rec.sid)
+                )
+        return super().unlink()
+
+    @api.model
+    def _ensure_summary_group(self):
+        settings = self.env["connect.settings"].sudo()
+        insight_id = settings.get_param("telnyx_ai_summary_insight_id")
+        group_id = settings.get_param("telnyx_ai_summary_group_id")
+        if insight_id and group_id:
+            return group_id
+        api_url = settings.get_param("api_url")
+        webhook = urljoin(api_url, "telnyx/webhook/assistant/insights")
+        if not insight_id:
+            insight = self._unwrap(settings.telnyx_api_request(
+                "POST", "ai/conversations/insights", payload={
+                    "name": "Odoo Connect Summary",
+                    "instructions": (
+                        "Summarize this conversation in 2-3 factual sentences. "
+                        "Include the request, outcome, and follow-up actions."
+                    ),
+                }
+            ))
+            insight_id = insight.get("id")
+            settings.set_param("telnyx_ai_summary_insight_id", insight_id)
+        if not group_id:
+            group = self._unwrap(settings.telnyx_api_request(
+                "POST", "ai/conversations/insight-groups", payload={
+                    "name": "Odoo Connect Summary",
+                    "description": "Conversation summaries synchronized to Odoo.",
+                    "webhook": webhook,
+                }
+            ))
+            group_id = group.get("id")
+            settings.set_param("telnyx_ai_summary_group_id", group_id)
+        settings.telnyx_api_request(
+            "POST",
+            "ai/conversations/insight-groups/{}/insights/{}/assign".format(
+                group_id, insight_id
+            ),
+        )
+        return group_id
+
+    @api.model
+    def sync(self):
+        self._ensure_summary_group()
+        response = self.env["connect.settings"].telnyx_api_request(
+            "GET", "ai/assistants"
+        )
+        data = self._unwrap(response) or []
+        if isinstance(data, dict):
+            data = data.get("assistants") or data.get("items") or []
+        for item in data:
+            sid = item.get("id")
+            if not sid:
+                continue
+            rec = self.search([("sid", "=", sid)], limit=1)
+            vals = self._remote_values(item, imported=not bool(rec))
+            if rec:
+                rec.with_context(skip_telnyx_ai_sync=True).write(vals)
+            else:
+                vals["tool_token"] = secrets.token_urlsafe(32)
+                rec = self.with_context(skip_telnyx_ai_sync=True).create(vals)
+                # Once imported, Odoo becomes the source of truth and adds
+                # its signed variables webhook plus the allowlisted tools.
+                rec._update_remote()
+        return True
+
+    def action_pull_from_telnyx(self):
+        for rec in self:
+            if not rec.sid:
+                rec._create_remote()
+                continue
+            data = self._unwrap(
+                self.env["connect.settings"].telnyx_api_request(
+                    "GET", "ai/assistants/{}".format(rec.sid)
+                )
+            )
+            rec._apply_remote_data(data)
+        return True
+
+    def action_push_to_telnyx(self):
+        for rec in self:
+            rec._update_remote()
+        return True
+
+    def action_rotate_tool_token(self):
+        for rec in self:
+            rec.sudo().with_context(skip_telnyx_ai_sync=True).tool_token = (
+                secrets.token_urlsafe(32)
+            )
+            rec._update_remote()
+        return True
+
+    def action_call_with_assistant(self):
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "name": "Call with Assistant",
+            "res_model": "connect.telnyx.ai_call_wizard",
+            "view_mode": "form",
+            "target": "new",
+            "context": {"default_assistant": self.id},
+        }
+
+    @api.model
+    def _partner_values(self, partner):
+        if not partner:
+            return {"found": False}
+        return {
+            "found": True,
+            "partner_id": partner.id,
+            "customer_name": partner.display_name,
+            "company_name": partner.parent_id.display_name or (
+                partner.display_name if partner.is_company else ""
+            ),
+            "email": partner.email or "",
+            "language": partner.lang or "",
+        }
+
+    def _resolve_partner(self, payload, call_control_id=None):
+        self.ensure_one()
+        phone = payload.get("phone")
+        if phone:
+            return self.env["res.partner"].sudo().get_partner_by_number(phone)
+        if call_control_id:
+            channel = self.env["connect.channel"].sudo().search(
+                [("sid", "=", call_control_id)], limit=1
+            )
+            if channel.call.partner:
+                return channel.call.partner
+        return self.env["res.partner"]
+
+    def execute_tool(self, tool_name, payload, call_control_id=None):
+        self.ensure_one()
+        allowed = {
+            "lookup_contact", "add_contact_note", "upsert_crm_lead",
+            "upsert_helpdesk_ticket",
+        }
+        if tool_name not in allowed:
+            raise ValidationError("Unknown AI assistant tool.")
+        if (tool_name in ("lookup_contact", "add_contact_note")
+                and not self.enable_contact_tools):
+            raise ValidationError("Contact tools are disabled.")
+        partner = self._resolve_partner(payload, call_control_id)
+        phone = payload.get("phone") or (
+            partner.phone or partner.mobile if partner else ""
+        )
+        if tool_name == "lookup_contact":
+            return self._partner_values(partner)
+        note = (payload.get("note") or "").strip()
+        if len(note) > 4000:
+            raise ValidationError("Tool note is too long.")
+        if tool_name == "add_contact_note":
+            if not partner:
+                return {"ok": False, "error": "contact_not_found"}
+            partner.sudo().message_post(
+                body=escape(note), subtype_xmlid="mail.mt_note"
+            )
+            return {"ok": True, "partner_id": partner.id}
+        title = (payload.get("title") or "").strip()[:255]
+        if not title:
+            raise ValidationError("A title is required.")
+        if tool_name == "upsert_crm_lead":
+            if not self.enable_crm_tools or "crm.lead" not in self.env:
+                return {"ok": False, "error": "crm_not_available"}
+            Lead = self.env["crm.lead"].sudo()
+            lead = Lead.get_lead_by_number(phone) if phone else Lead
+            if not lead:
+                lead = Lead.create({
+                    "name": title,
+                    "phone": phone,
+                    "partner_id": partner.id if partner else False,
+                })
+            if note:
+                lead.message_post(body=escape(note), subtype_xmlid="mail.mt_note")
+            return {"ok": True, "lead_id": lead.id}
+        if not self.enable_helpdesk_tools or "helpdesk.ticket" not in self.env:
+            return {"ok": False, "error": "helpdesk_not_available"}
+        Ticket = self.env["helpdesk.ticket"].sudo()
+        ticket = Ticket.get_ticket_by_number(phone) if phone else Ticket
+        if not ticket:
+            ticket = Ticket.create({
+                "name": title,
+                "partner_id": partner.id if partner else False,
+                "partner_phone": phone,
+            })
+        if note:
+            ticket.message_post(body=escape(note), subtype_xmlid="mail.mt_note")
+        return {"ok": True, "ticket_id": ticket.id}

--- a/connect_telnyx/models/ai_assistant.py
+++ b/connect_telnyx/models/ai_assistant.py
@@ -116,7 +116,7 @@ class TelnyxAIAssistant(models.Model):
 
     def _tool_payload(self):
         self.ensure_one()
-        tools = [{"type": "hangup"}]
+        tools = [{"type": "hangup", "hangup": {}}]
         if self.enable_contact_tools:
             tools.extend([
                 self._webhook_tool(

--- a/connect_telnyx/models/ai_assistant.py
+++ b/connect_telnyx/models/ai_assistant.py
@@ -272,7 +272,10 @@ class TelnyxAIAssistant(models.Model):
             vals.setdefault("tool_token", secrets.token_urlsafe(32))
         records = super().create(vals_list)
         if (self.env.context.get("install_mode")
-                or self.env.context.get("skip_telnyx_ai_sync")):
+                or self.env.context.get("skip_telnyx_ai_sync")
+                or not self.env["connect.settings"].sudo().get_param(
+                    "telnyx_auto_sync"
+                )):
             return records
         for rec in records:
             rec._create_remote()

--- a/connect_telnyx/models/call.py
+++ b/connect_telnyx/models/call.py
@@ -16,6 +16,15 @@ logger = logging.getLogger(__name__)
 class Call(models.Model):
     _inherit = 'connect.call'
 
+    telnyx_ai_assistant = fields.Many2one(
+        'connect.telnyx.ai_assistant', string='Telnyx AI Assistant',
+        ondelete='set null', readonly=True,
+    )
+    telnyx_ai_conversation_id = fields.Char(
+        string='Telnyx AI Conversation', readonly=True, copy=False, index=True,
+    )
+    telnyx_ai_last_sync_at = fields.Datetime(readonly=True, copy=False)
+
     @api.model
     def telnyx_on_call_action(self, params):
         debug(self, 'On call action: %s' % params)
@@ -215,3 +224,187 @@ class Call(models.Model):
                     'Error fetching cost for call %s: %s', call.id, e
                 )
         debug(self, 'Batch cost fetch completed')
+
+    @api.model
+    def telnyx_link_ai_conversation(self, payload):
+        """Link the assistant initialization event to the TeXML call ledger."""
+        self = self.sudo()
+        assistant_sid = payload.get('assistant_id')
+        call_control_id = payload.get('call_control_id')
+        conversation_id = (
+            payload.get('telnyx_conversation_id')
+            or payload.get('conversation_id')
+        )
+        assistant = self.env['connect.telnyx.ai_assistant'].search(
+            [('sid', '=', assistant_sid)], limit=1)
+        channel = self.env['connect.channel'].search(
+            [('sid', '=', call_control_id)], limit=1)
+        call = channel.call
+        if call:
+            call.write({
+                'telnyx_ai_assistant': assistant.id,
+                'telnyx_ai_conversation_id': conversation_id or False,
+                'telnyx_ai_last_sync_at': fields.Datetime.now(),
+            })
+        return call
+
+    @api.model
+    def _telnyx_ai_transcript(self, messages):
+        lines = []
+        for message in messages:
+            role = (message.get('role') or 'unknown').upper()
+            text = message.get('text') or message.get('content') or ''
+            if isinstance(text, list):
+                text = ' '.join(
+                    item.get('text', '') if isinstance(item, dict) else str(item)
+                    for item in text
+                )
+            if text:
+                lines.append('{}: {}'.format(role, text))
+        return '\n'.join(lines)
+
+    @api.model
+    def _telnyx_ai_summary(self, insights):
+        for batch in reversed(insights or []):
+            for insight in batch.get('conversation_insights') or []:
+                result = insight.get('result')
+                if result:
+                    return result if isinstance(result, str) else json.dumps(
+                        result, ensure_ascii=False)
+        return ''
+
+    @api.model
+    def _telnyx_find_ai_call(self, conversation):
+        metadata = conversation.get('metadata') or {}
+        conversation_id = conversation.get('id')
+        call = self.sudo().search(
+            [('telnyx_ai_conversation_id', '=', conversation_id)], limit=1)
+        if call:
+            return call
+        call_control_id = metadata.get('call_control_id')
+        if call_control_id:
+            channel = self.env['connect.channel'].sudo().search(
+                [('sid', '=', call_control_id)], limit=1)
+            if channel.call:
+                return channel.call
+        agent_target = metadata.get('telnyx_agent_target')
+        end_user = metadata.get('telnyx_end_user_target')
+        if agent_target and end_user:
+            return self.sudo().search([
+                '|',
+                '&', ('called', '=', agent_target), ('caller', '=', end_user),
+                '&', ('caller', '=', agent_target), ('called', '=', end_user),
+            ], order='create_date desc', limit=1)
+        return self
+
+    @api.model
+    def telnyx_sync_ai_conversation(self, conversation, summary=None):
+        settings = self.env['connect.settings']
+        conversation_id = conversation.get('id')
+        if not conversation_id:
+            return False
+        call = self._telnyx_find_ai_call(conversation)
+        if not call:
+            return False
+        metadata = conversation.get('metadata') or {}
+        assistant = self.env['connect.telnyx.ai_assistant'].sudo().search(
+            [('sid', '=', metadata.get('assistant_id'))], limit=1)
+        messages_response = settings.telnyx_api_request(
+            'GET', 'ai/conversations/{}/messages'.format(conversation_id)
+        )
+        messages = messages_response.get('data', messages_response)
+        if not isinstance(messages, list):
+            messages = []
+        if summary is None:
+            insights_response = settings.telnyx_api_request(
+                'GET',
+                'ai/conversations/{}/conversations-insights'.format(
+                    conversation_id),
+            )
+            insights = insights_response.get('data', insights_response)
+            summary = self._telnyx_ai_summary(
+                insights if isinstance(insights, list) else []
+            )
+        transcript = self._telnyx_ai_transcript(messages)
+        channel = call.channels.filtered(
+            lambda rec: rec.sid == metadata.get('call_control_id'))[:1]
+        vals = {
+            'sid': conversation_id,
+            'call_sid': metadata.get('call_control_id') or '',
+            'call': call.id,
+            'channel': channel.id,
+            'partner': call.partner.id,
+            'caller_number': call.caller,
+            'called_number': call.called,
+            'source': 'telnyx-ai',
+            'status': 'completed',
+            'transcript': transcript,
+            'summary': summary or '',
+        }
+        recording = self.env['connect.recording'].sudo().search(
+            [('sid', '=', conversation_id), ('source', '=', 'telnyx-ai')],
+            limit=1,
+        )
+        if recording:
+            recording.with_context(skip_transcription=True).write(vals)
+        else:
+            recording = self.env['connect.recording'].sudo().with_context(
+                skip_transcription=True
+            ).create(vals)
+        call.write({
+            'telnyx_ai_assistant': assistant.id,
+            'telnyx_ai_conversation_id': conversation_id,
+            'telnyx_ai_last_sync_at': fields.Datetime.now(),
+            'summary': summary or call.summary,
+        })
+        return recording
+
+    @api.model
+    def telnyx_apply_ai_insights(self, payload):
+        conversation_id = (
+            payload.get('conversation_id')
+            or (payload.get('data') or {}).get('conversation_id')
+        )
+        if not conversation_id:
+            return False
+        insight_items = payload.get('insights') or (
+            payload.get('data') or {}).get('insights') or []
+        summary = ''
+        for item in insight_items:
+            if item.get('result'):
+                result = item['result']
+                summary = result if isinstance(result, str) else json.dumps(
+                    result, ensure_ascii=False)
+                break
+        conversation_response = self.env[
+            'connect.settings'
+        ].telnyx_api_request(
+            'GET', 'ai/conversations/{}'.format(conversation_id)
+        )
+        conversation = conversation_response.get('data', conversation_response)
+        return self.telnyx_sync_ai_conversation(
+            conversation, summary=summary or None)
+
+    @api.model
+    def telnyx_sync_ai_conversations_batch(self, limit=50):
+        settings = self.env['connect.settings'].sudo()
+        if not settings.get_param('telnyx_api_key'):
+            return False
+        response = settings.telnyx_api_request(
+            'GET', 'ai/conversations', params={
+                'metadata->telnyx_conversation_channel': 'eq.phone_call',
+                'limit': limit,
+                'order': 'last_message_at.desc',
+            })
+        conversations = response.get('data', response)
+        if not isinstance(conversations, list):
+            return False
+        for conversation in conversations:
+            try:
+                self.telnyx_sync_ai_conversation(conversation)
+            except Exception:
+                logger.exception(
+                    'Cannot sync Telnyx AI conversation %s',
+                    conversation.get('id'),
+                )
+        return True

--- a/connect_telnyx/models/number.py
+++ b/connect_telnyx/models/number.py
@@ -7,6 +7,7 @@ from odoo.exceptions import ValidationError
 
 from odoo.addons.connect.models.settings import debug
 from .settings import format_connect_response
+from .texml_response import Connect, VoiceResponse
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +25,7 @@ class Number(models.Model):
         ('user', 'User'),
         ('callflow', 'CallFlow'),
         ('texml', 'TeXML'),
+        ('ai_assistant', 'AI Assistant'),
     ], ondelete='set null')
     callflow = fields.Many2one('connect.telnyx.callflow', ondelete='set null')
     user = fields.Many2one('connect.user', ondelete='set null')
@@ -31,6 +33,10 @@ class Number(models.Model):
     sid = fields.Char()
     texml = fields.Many2one(
         'connect.telnyx.texml', string='TeXML', ondelete='set null'
+    )
+    ai_assistant = fields.Many2one(
+        'connect.telnyx.ai_assistant', string='AI Assistant',
+        ondelete='set null',
     )
 
     def update_telnyx_number(self, client):
@@ -75,7 +81,7 @@ class Number(models.Model):
 
     def write(self, vals):
         if 'destination' in vals:
-            for field in ['user', 'callflow', 'texml']:
+            for field in ['user', 'callflow', 'texml', 'ai_assistant']:
                 if field != vals['destination']:
                     vals.update({field: None})
         res = super().write(vals)
@@ -141,6 +147,14 @@ class Number(models.Model):
             return self.user.telnyx_render(request)
         elif self.destination == 'callflow' and self.callflow:
             return self.callflow.render(request)
+        elif self.destination == 'ai_assistant' and self.ai_assistant:
+            if not self.ai_assistant.sid:
+                return '<Response><Say>AI assistant is not synchronized.</Say></Response>'
+            response = VoiceResponse()
+            connect = Connect()
+            connect.ai_assistant(self.ai_assistant.sid)
+            response.append(connect)
+            return response.to_xml()
         else:
             return '<Response><Say>Number not configured. Goodbye!</Say></Response>'
 

--- a/connect_telnyx/models/settings.py
+++ b/connect_telnyx/models/settings.py
@@ -3,6 +3,8 @@ import logging
 import re
 from urllib.parse import urljoin
 
+import requests
+
 from odoo import fields, models, api, release
 from odoo.exceptions import ValidationError
 from telnyx import Telnyx
@@ -22,6 +24,8 @@ MAX_EXTEN_LEN = 4
 TELNYX_PROTECTED_FIELDS = [
     "display_telnyx_api_key",
 ]
+
+TELNYX_API_BASE = "https://api.telnyx.com/v2/"
 
 
 def format_connect_response(text):
@@ -58,6 +62,8 @@ class Settings(models.Model):
     # endpoint for it (ADR-032).
     telnyx_account_sid = fields.Char(string="Telnyx Account SID")
     telnyx_messaging_profile_id = fields.Char(readonly=True)
+    telnyx_ai_summary_insight_id = fields.Char(readonly=True)
+    telnyx_ai_summary_group_id = fields.Char(readonly=True)
     telnyx_balance = fields.Char(readonly=True)
     telnyx_auto_sync = fields.Boolean(default=True)
     telnyx_verify_requests = fields.Boolean(
@@ -79,6 +85,59 @@ class Settings(models.Model):
         public_key = self.sudo().get_param("telnyx_public_key")
         return Telnyx(api_key=api_key, public_key=public_key or None)
 
+    @api.model
+    def telnyx_api_request(self, method, path, payload=None, params=None,
+                           timeout=20):
+        """Call Telnyx v2 endpoints not consistently exposed by SDK releases.
+
+        The account key never appears in error messages or debug output.  The
+        returned value is the decoded JSON body; callers normalize the few
+        endpoints that wrap their result in ``data`` themselves.
+        """
+        api_key = self.sudo().get_param("telnyx_api_key")
+        if not api_key:
+            raise ValidationError("Set Telnyx API key first!")
+        url = urljoin(TELNYX_API_BASE, path.lstrip("/"))
+        try:
+            response = requests.request(
+                method.upper(), url,
+                headers={
+                    "Authorization": "Bearer {}".format(api_key),
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+                params=params,
+                timeout=timeout,
+            )
+        except requests.RequestException as exc:
+            raise ValidationError(
+                "Telnyx API request failed: {}".format(exc)
+            ) from exc
+        if response.status_code >= 400:
+            try:
+                body = response.json()
+                detail = (
+                    body.get("errors") or body.get("detail")
+                    or body.get("message") or body.get("error")
+                )
+            except ValueError:
+                detail = None
+            raise ValidationError(
+                "Telnyx API returned HTTP {}{}".format(
+                    response.status_code,
+                    ": {}".format(detail) if detail else "",
+                )
+            )
+        if response.status_code == 204 or not response.content:
+            return {}
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise ValidationError(
+                "Telnyx API returned an invalid JSON response."
+            ) from exc
+
     def telnyx_sync(self):
         if not self.sudo().get_param("telnyx_api_key"):
             raise ValidationError("You must set the Telnyx API key!")
@@ -88,6 +147,7 @@ class Settings(models.Model):
         try:
             self._ensure_telnyx_messaging_profile()
             self.env["connect.telnyx.texml"].sync()
+            self.env["connect.telnyx.ai_assistant"].sync()
             self.env["connect.telnyx.domain"].sync()
             self.env["connect.telnyx.number"].sync()
             self.env["connect.telnyx.outgoing_callerid"].sync()

--- a/connect_telnyx/models/texml_response.py
+++ b/connect_telnyx/models/texml_response.py
@@ -92,6 +92,14 @@ class Dial(TeXML):
         return self._add('Conference', name, **attrs)
 
 
+class Connect(TeXML):
+    tag = 'Connect'
+
+    def ai_assistant(self, assistant_id, **attrs):
+        attrs['id'] = assistant_id
+        return self._add('AIAssistant', **attrs)
+
+
 def pretty_xml(content):
     try:
         dom = parseString(str(content))

--- a/connect_telnyx/security/access_rules.xml
+++ b/connect_telnyx/security/access_rules.xml
@@ -397,4 +397,45 @@
         <field name="perm_unlink" eval="True"/>
     </record>
 
+    <!-- Telnyx AI assistants: admins manage, users and webhook identity read. -->
+    <record id="access_connect_telnyx_ai_assistant_admin" model="ir.model.access">
+        <field name="name">connect.telnyx.ai_assistant admin</field>
+        <field name="model_id" ref="model_connect_telnyx_ai_assistant"/>
+        <field name="group_id" ref="connect.group_admin"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+
+    <record id="access_connect_telnyx_ai_assistant_user" model="ir.model.access">
+        <field name="name">connect.telnyx.ai_assistant user</field>
+        <field name="model_id" ref="model_connect_telnyx_ai_assistant"/>
+        <field name="group_id" ref="connect.group_user"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+
+    <record id="access_connect_telnyx_ai_assistant_webhook" model="ir.model.access">
+        <field name="name">connect.telnyx.ai_assistant webhook</field>
+        <field name="model_id" ref="model_connect_telnyx_ai_assistant"/>
+        <field name="group_id" ref="connect.group_webhook"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+
+    <record id="access_connect_telnyx_ai_call_wizard_admin" model="ir.model.access">
+        <field name="name">connect.telnyx.ai_call_wizard admin</field>
+        <field name="model_id" ref="model_connect_telnyx_ai_call_wizard"/>
+        <field name="group_id" ref="connect.group_admin"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+
 </odoo>

--- a/connect_telnyx/tests/__init__.py
+++ b/connect_telnyx/tests/__init__.py
@@ -17,6 +17,8 @@ import importlib.util
 import os
 import sys
 
+from . import test_ai_assistant
+
 _SUITE = os.path.normpath(
     os.path.join(os.path.dirname(__file__), "..", "..",
                  "tests_suite", "connect_telnyx", "tests")

--- a/connect_telnyx/tests/test_ai_assistant.py
+++ b/connect_telnyx/tests/test_ai_assistant.py
@@ -43,8 +43,6 @@ class TestTelnyxAIAssistant(TransactionCase):
         number = self.env['connect.telnyx.number'].create({
             'phone_number': '+15550001111',
             'sid': 'number-test',
-        })
-        number.with_context(skip_telnyx_sync=True).write({
             'destination': 'ai_assistant',
             'ai_assistant': self.assistant.id,
         })

--- a/connect_telnyx/tests/test_ai_assistant.py
+++ b/connect_telnyx/tests/test_ai_assistant.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+from unittest.mock import patch
+
+from odoo.tests import TransactionCase, tagged
+
+from odoo.addons.connect_telnyx.models.settings import Settings
+
+
+@tagged('at_install', '-post_install')
+class TestTelnyxAIAssistant(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env['ir.config_parameter'].sudo().set_param(
+            'connect.api_url', 'https://odoo.example.test/')
+        cls.Assistant = cls.env['connect.telnyx.ai_assistant'].with_context(
+            skip_telnyx_ai_sync=True)
+        cls.assistant = cls.Assistant.create({
+            'name': 'Support Agent',
+            'instructions': 'Help the caller.',
+            'sid': 'assistant-test',
+        })
+
+    def test_remote_payload_has_safe_defaults_and_tools(self):
+        payload = self.assistant._remote_payload()
+        self.assertEqual(payload['enabled_features'], ['telephony'])
+        self.assertFalse(
+            payload['telephony_settings']['recording_settings']['enabled'])
+        tool_names = [
+            item.get('webhook', {}).get('name') for item in payload['tools']
+        ]
+        self.assertIn('lookup_contact', tool_names)
+        self.assertIn('add_contact_note', tool_names)
+        self.assertNotIn('upsert_crm_lead', tool_names)
+        webhook = next(
+            item['webhook'] for item in payload['tools']
+            if item.get('webhook', {}).get('name') == 'lookup_contact')
+        self.assertEqual(
+            webhook['headers'][0]['value'], self.assistant.tool_token)
+
+    def test_number_renders_ai_assistant_texml(self):
+        number = self.env['connect.telnyx.number'].create({
+            'phone_number': '+15550001111',
+            'sid': 'number-test',
+        })
+        number.with_context(skip_telnyx_sync=True).write({
+            'destination': 'ai_assistant',
+            'ai_assistant': self.assistant.id,
+        })
+        xml = number.render()
+        self.assertIn('<Connect>', xml)
+        self.assertIn('<AIAssistant id="assistant-test"', xml)
+
+    def test_sync_imports_remote_assistant_idempotently(self):
+        settings = self.env['connect.settings'].sudo()
+        settings.set_param('telnyx_ai_summary_insight_id', 'insight-test')
+        settings.set_param('telnyx_ai_summary_group_id', 'group-test')
+        remote_item = {
+                'id': 'assistant-imported',
+                'name': 'Imported Agent',
+                'instructions': 'Imported instructions.',
+                'greeting': 'Hello',
+                'telephony_settings': {
+                    'time_limit_secs': 600,
+                    'recording_settings': {'enabled': True},
+                },
+            }
+
+        def api_response(_settings, method, path, **kwargs):
+            if method == 'GET' and path == 'ai/assistants':
+                return {'data': [remote_item]}
+            return remote_item
+
+        with patch.object(
+                Settings, 'telnyx_api_request', autospec=True,
+                side_effect=api_response):
+            self.env['connect.telnyx.ai_assistant'].sync()
+            self.env['connect.telnyx.ai_assistant'].sync()
+        records = self.env['connect.telnyx.ai_assistant'].search([
+            ('sid', '=', 'assistant-imported')])
+        self.assertEqual(len(records), 1)
+        self.assertTrue(records.imported)
+        self.assertTrue(records.record_calls)
+
+    def test_contact_tool_is_allowlisted(self):
+        partner = self.env['res.partner'].create({
+            'name': 'AI Caller', 'phone': '+15550002222'})
+        result = self.assistant.execute_tool(
+            'lookup_contact', {'phone': '+15550002222'})
+        self.assertTrue(result['found'])
+        self.assertEqual(result['partner_id'], partner.id)
+        result = self.assistant.execute_tool(
+            'add_contact_note', {
+                'phone': '+15550002222', 'note': 'Requested a callback.'})
+        self.assertTrue(result['ok'])
+        self.assertTrue(partner.message_ids)
+
+    def test_conversation_sync_is_idempotent(self):
+        call = self.env['connect.call'].create({
+            'caller': '+15550003333',
+            'called': '+15550004444',
+            'status': 'completed',
+            'direction': 'incoming',
+        })
+        self.env['connect.channel'].create({
+            'sid': 'v3:test-call',
+            'call': call.id,
+            'caller': '+15550003333',
+            'called': '+15550004444',
+            'status': 'completed',
+            'technical_direction': 'inbound',
+        })
+        conversation = {
+            'id': 'conversation-test',
+            'metadata': {
+                'assistant_id': self.assistant.sid,
+                'call_control_id': 'v3:test-call',
+                'telnyx_conversation_channel': 'phone_call',
+            },
+        }
+
+        def api_response(_settings, _method, path, **kwargs):
+            if path.endswith('/messages'):
+                return {'data': [
+                    {'role': 'user', 'text': 'I need help.'},
+                    {'role': 'assistant', 'text': 'I can help.'},
+                ]}
+            return {'data': [{
+                'status': 'completed',
+                'conversation_insights': [{'result': 'Issue resolved.'}],
+            }]}
+
+        with patch.object(
+                Settings, 'telnyx_api_request', autospec=True,
+                side_effect=api_response):
+            self.env['connect.call'].telnyx_sync_ai_conversation(conversation)
+            self.env['connect.call'].telnyx_sync_ai_conversation(conversation)
+        recordings = self.env['connect.recording'].search([
+            ('sid', '=', 'conversation-test'), ('source', '=', 'telnyx-ai')])
+        self.assertEqual(len(recordings), 1)
+        self.assertIn('USER: I need help.', recordings.transcript)
+        self.assertEqual(call.telnyx_ai_conversation_id, 'conversation-test')

--- a/connect_telnyx/tests/test_ai_assistant.py
+++ b/connect_telnyx/tests/test_ai_assistant.py
@@ -83,6 +83,69 @@ class TestTelnyxAIAssistant(TransactionCase):
         self.assertTrue(records.imported)
         self.assertTrue(records.record_calls)
 
+    def test_create_respects_auto_sync_disabled(self):
+        settings = self.env['connect.settings'].sudo()
+        settings.set_param('telnyx_auto_sync', False)
+        try:
+            with patch.object(
+                    Settings, 'telnyx_api_request', autospec=True
+            ) as request_mock:
+                assistant = self.env['connect.telnyx.ai_assistant'].create({
+                    'name': 'Local Draft Agent',
+                    'instructions': 'Stay local.',
+                })
+        finally:
+            settings.set_param('telnyx_auto_sync', True)
+        self.assertFalse(assistant.sid)
+        request_mock.assert_not_called()
+
+    def test_ai_call_wizard_uses_texml_connection_endpoint(self):
+        texml = self.env['connect.telnyx.texml'].with_context(
+            install_mode=True
+        ).create({
+            'name': 'Routing App',
+            'code_type': 'model_method',
+            'model': 'connect.telnyx.domain',
+            'method': 'route_call',
+            'sid': 'texml-connection-test',
+        })
+        self.env['connect.telnyx.domain'].with_context(
+            no_telnyx_create=True
+        ).create({
+            'friendly_name': 'Test Domain',
+            'subdomain': 'test-ai',
+            'application': texml.id,
+        })
+        caller_id = self.env['connect.telnyx.outgoing_callerid'].create({
+            'number': '+15550009999',
+            'friendly_name': 'Test caller',
+        })
+        partner = self.env['res.partner'].create({
+            'name': 'AI Callee', 'phone': '+15550008888'})
+        wizard = self.env['connect.telnyx.ai_call_wizard'].create({
+            'assistant': self.assistant.id,
+            'caller_id': caller_id.id,
+            'to_number': '15550008888',
+            'partner': partner.id,
+        })
+
+        def api_response(_settings, method, path, **kwargs):
+            self.assertEqual(method, 'POST')
+            self.assertEqual(path, 'texml/ai_calls/texml-connection-test')
+            self.assertEqual(kwargs['payload']['To'], '+15550008888')
+            self.assertEqual(
+                kwargs['payload']['AIAssistantId'], self.assistant.sid)
+            return {'call_sid': 'v3:test-ai-call'}
+
+        with patch.object(
+                Settings, 'telnyx_api_request', autospec=True,
+                side_effect=api_response):
+            wizard.action_call()
+        channel = self.env['connect.channel'].search([
+            ('sid', '=', 'v3:test-ai-call')])
+        self.assertEqual(len(channel), 1)
+        self.assertEqual(channel.called, '+15550008888')
+
     def test_contact_tool_is_allowlisted(self):
         partner = self.env['res.partner'].create({
             'name': 'AI Caller', 'phone': '+15550002222'})

--- a/connect_telnyx/tests/test_ai_assistant.py
+++ b/connect_telnyx/tests/test_ai_assistant.py
@@ -25,6 +25,8 @@ class TestTelnyxAIAssistant(TransactionCase):
     def test_remote_payload_has_safe_defaults_and_tools(self):
         payload = self.assistant._remote_payload()
         self.assertEqual(payload['enabled_features'], ['telephony'])
+        self.assertEqual(payload['tools'][0], {
+            'type': 'hangup', 'hangup': {}})
         self.assertFalse(
             payload['telephony_settings']['recording_settings']['enabled'])
         tool_names = [

--- a/connect_telnyx/views/ai_assistant_views.xml
+++ b/connect_telnyx/views/ai_assistant_views.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_telnyx_ai_assistant_list" model="ir.ui.view">
+        <field name="name">connect.telnyx.ai_assistant.list</field>
+        <field name="model">connect.telnyx.ai_assistant</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="name"/>
+                <field name="model"/>
+                <field name="voice"/>
+                <field name="record_calls"/>
+                <field name="memory_enabled"/>
+                <field name="sid"/>
+                <field name="last_sync_at"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="view_telnyx_ai_assistant_form" model="ir.ui.view">
+        <field name="name">connect.telnyx.ai_assistant.form</field>
+        <field name="model">connect.telnyx.ai_assistant</field>
+        <field name="arch" type="xml">
+            <form>
+                <header>
+                    <button name="action_call_with_assistant" type="object"
+                            string="Call with Assistant" class="btn-primary"
+                            invisible="not sid"/>
+                    <button name="action_push_to_telnyx" type="object"
+                            string="Push to Telnyx"/>
+                    <button name="action_pull_from_telnyx" type="object"
+                            string="Pull from Telnyx" invisible="not sid"/>
+                    <button name="action_rotate_tool_token" type="object"
+                            string="Rotate Tool Token"/>
+                </header>
+                <sheet>
+                    <div class="oe_title">
+                        <h1><field name="name" placeholder="Assistant name..."/></h1>
+                    </div>
+                    <group>
+                        <group string="Telnyx">
+                            <field name="sid"/>
+                            <field name="version_id"/>
+                            <field name="imported"/>
+                            <field name="last_sync_at"/>
+                            <field name="active"/>
+                        </group>
+                        <group string="Model and Voice">
+                            <field name="model"/>
+                            <field name="voice"/>
+                            <field name="voice_speed"/>
+                            <field name="transcription_model"/>
+                            <field name="transcription_language"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Agent" name="agent">
+                            <group>
+                                <field name="description"/>
+                                <field name="greeting"/>
+                                <field name="instructions"/>
+                            </group>
+                        </page>
+                        <page string="Calling" name="calling">
+                            <group>
+                                <field name="time_limit_secs"/>
+                                <field name="record_calls"/>
+                                <field name="memory_enabled"/>
+                            </group>
+                        </page>
+                        <page string="Odoo Tools" name="odoo_tools">
+                            <group>
+                                <field name="enable_contact_tools"/>
+                                <field name="enable_crm_tools"
+                                       help="Published only when Connect CRM is installed."/>
+                                <field name="enable_helpdesk_tools"
+                                       help="Published only when Connect Helpdesk is installed."/>
+                            </group>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_telnyx_ai_assistant" model="ir.actions.act_window">
+        <field name="name">AI Assistants</field>
+        <field name="res_model">connect.telnyx.ai_assistant</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <menuitem id="menu_telnyx_ai_assistants"
+              name="AI Assistants"
+              parent="menu_connect_telnyx"
+              action="action_telnyx_ai_assistant"
+              groups="connect.group_admin"
+              sequence="20"/>
+</odoo>

--- a/connect_telnyx/views/call_views.xml
+++ b/connect_telnyx/views/call_views.xml
@@ -13,6 +13,14 @@
                         <field name="telnyx_price_unit"/>
                         <field name="telnyx_is_price_fetched"/>
                     </group>
+                    <group string="AI Assistant" invisible="not telnyx_ai_assistant">
+                        <field name="telnyx_ai_assistant"/>
+                        <field name="telnyx_ai_conversation_id"/>
+                        <field name="telnyx_ai_last_sync_at"/>
+                    </group>
+                    <group string="AI Transcript" invisible="not transcript">
+                        <field name="transcript" nolabel="1" colspan="2"/>
+                    </group>
                 </page>
             </xpath>
         </field>

--- a/connect_telnyx/views/number_views.xml
+++ b/connect_telnyx/views/number_views.xml
@@ -11,6 +11,7 @@
                 <field name="user"/>
                 <field name="callflow"/>
                 <field name="texml"/>
+                <field name="ai_assistant"/>
                 <field name="is_ignored"/>
             </list>
         </field>
@@ -36,6 +37,9 @@
                             <field name="texml"
                                    invisible="destination != 'texml'"
                                    required="destination == 'texml'"/>
+                            <field name="ai_assistant"
+                                   invisible="destination != 'ai_assistant'"
+                                   required="destination == 'ai_assistant'"/>
                         </group>
                     </group>
                 </sheet>

--- a/connect_telnyx/views/settings_views.xml
+++ b/connect_telnyx/views/settings_views.xml
@@ -41,6 +41,8 @@
                                 </group>
                                 <group string="Messaging">
                                     <field name="telnyx_messaging_profile_id" readonly="1"/>
+                                    <field name="telnyx_ai_summary_insight_id" readonly="1"/>
+                                    <field name="telnyx_ai_summary_group_id" readonly="1"/>
                                 </group>
                             </group>
                         </page>

--- a/connect_telnyx/wizard/__init__.py
+++ b/connect_telnyx/wizard/__init__.py
@@ -1,3 +1,4 @@
 from . import sms_composer
 from . import whatsapp_composer
 from . import rcs_composer
+from . import ai_call_wizard

--- a/connect_telnyx/wizard/ai_call_wizard.py
+++ b/connect_telnyx/wizard/ai_call_wizard.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, models
+from odoo.exceptions import ValidationError
+
+
+class TelnyxAICallWizard(models.TransientModel):
+    _name = 'connect.telnyx.ai_call_wizard'
+    _description = 'Call with Telnyx AI Assistant'
+
+    assistant = fields.Many2one(
+        'connect.telnyx.ai_assistant', required=True, ondelete='cascade'
+    )
+    caller_id = fields.Many2one(
+        'connect.telnyx.outgoing_callerid', required=True,
+    )
+    to_number = fields.Char(required=True)
+    partner = fields.Many2one('res.partner', ondelete='set null')
+
+    def action_call(self):
+        self.ensure_one()
+        if not self.assistant.sid:
+            raise ValidationError('Synchronize the AI assistant first.')
+        if not self.caller_id.number:
+            raise ValidationError('Select a valid Telnyx caller ID.')
+        number = self.to_number.strip()
+        if not number.startswith('+'):
+            number = '+{}'.format(number)
+        dynamic_variables = {}
+        if self.partner:
+            dynamic_variables = {
+                'customer_name': self.partner.display_name,
+                'odoo_partner_id': str(self.partner.id),
+                'customer_email': self.partner.email or '',
+                'customer_language': self.partner.lang or '',
+            }
+        response = self.env['connect.settings'].telnyx_api_request(
+            'POST', 'texml/ai_calls', payload={
+                'From': self.caller_id.number,
+                'To': number,
+                'AIAssistantId': self.assistant.sid,
+                'AIAssistantDynamicVariables': dynamic_variables,
+            })
+        data = response.get('data', response)
+        call_sid = data.get('CallSid') or data.get('call_sid') or data.get('id')
+        if call_sid:
+            self.env['connect.channel'].sudo().create({
+                'sid': call_sid,
+                'technical_direction': 'outbound-api',
+                'status': 'initiated',
+                'caller': self.caller_id.number,
+                'called': number,
+                'partner': self.partner.id,
+            })
+        self.env['connect.settings'].connect_notify(
+            'Telnyx AI call started.', title='AI Assistant'
+        )
+        return {'type': 'ir.actions.act_window_close'}

--- a/connect_telnyx/wizard/ai_call_wizard.py
+++ b/connect_telnyx/wizard/ai_call_wizard.py
@@ -16,6 +16,15 @@ class TelnyxAICallWizard(models.TransientModel):
     to_number = fields.Char(required=True)
     partner = fields.Many2one('res.partner', ondelete='set null')
 
+    def _texml_connection_id(self):
+        domain = self.env['connect.telnyx.domain'].search([], limit=1)
+        connection_id = domain.application.sid if domain else False
+        if not connection_id:
+            raise ValidationError(
+                'Synchronize the Telnyx routing TeXML application first.'
+            )
+        return connection_id
+
     def action_call(self):
         self.ensure_one()
         if not self.assistant.sid:
@@ -34,7 +43,8 @@ class TelnyxAICallWizard(models.TransientModel):
                 'customer_language': self.partner.lang or '',
             }
         response = self.env['connect.settings'].telnyx_api_request(
-            'POST', 'texml/ai_calls', payload={
+            'POST', 'texml/ai_calls/{}'.format(self._texml_connection_id()),
+            payload={
                 'From': self.caller_id.number,
                 'To': number,
                 'AIAssistantId': self.assistant.sid,

--- a/connect_telnyx/wizard/ai_call_wizard_views.xml
+++ b/connect_telnyx/wizard/ai_call_wizard_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_telnyx_ai_call_wizard_form" model="ir.ui.view">
+        <field name="name">connect.telnyx.ai_call_wizard.form</field>
+        <field name="model">connect.telnyx.ai_call_wizard</field>
+        <field name="arch" type="xml">
+            <form string="Call with Assistant">
+                <group>
+                    <field name="assistant"/>
+                    <field name="caller_id"/>
+                    <field name="to_number" widget="phone"/>
+                    <field name="partner"/>
+                </group>
+                <footer>
+                    <button name="action_call" type="object" string="Call"
+                            class="btn-primary"/>
+                    <button string="Cancel" special="cancel" class="btn-secondary"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/docs/admin/telnyx-setup.md
+++ b/docs/admin/telnyx-setup.md
@@ -13,6 +13,28 @@
 
 Navigate to **Connect > Telnyx > Configuration > Settings**.
 
+## AI Voice Assistants
+
+After the credentials and public HTTPS API URL are configured, open
+**Connect > Telnyx > AI Assistants**. Creating a record creates the Telnyx AI
+Assistant and configures its dynamic-variable and tool webhooks. **Pull from
+Telnyx** refreshes a record; the main **SYNC TELNYX ACCOUNT** action also
+imports assistants created in Mission Control.
+
+To answer an existing Telnyx number with an assistant, open the number and set
+**Destination** to **AI Assistant**. The number remains attached to the Odoo
+TeXML routing application; do not assign it directly to the assistant in
+Mission Control.
+
+The **Call with Assistant** button starts an outbound call using an existing
+owned caller ID. It never buys or assigns a number. Recording and memory are
+off by default and must be enabled on each assistant. CRM and Helpdesk tools
+are published only when the matching Connect modules are installed.
+
+Telnyx signs context and insight callbacks with the account Ed25519 public
+key. Odoo tools use a separate random token per assistant; rotate it from the
+assistant form if it may have been exposed.
+
 ### Credentials
 
 | Field | Description |

--- a/specs/connect_telnyx.md
+++ b/specs/connect_telnyx.md
@@ -51,6 +51,19 @@ WhatsApp and RCS **messaging** are integrated (ADR-033).
 
 ## Models (connect_telnyx/models/)
 
+### ai_assistant.py — `connect.telnyx.ai_assistant`
+
+Manages Telnyx Voice AI Assistants through the v2 API. Stores the prompt,
+greeting, model/voice/transcription settings, recording/memory switches and
+the Odoo tool allowlist. Unknown remote assistants are imported by account
+sync; once imported, Odoo configures its signed dynamic-variables webhook and
+per-assistant tool endpoints. Phone numbers route to assistants through the
+existing TeXML application using `<Connect><AIAssistant>` (ADR-034).
+
+Completed AI conversations are linked to `connect.call` by conversation and
+Call Control IDs. Transcript and Telnyx Insight summary are stored on an
+idempotent `connect.recording` row with `source = telnyx-ai`.
+
 ### texml_response.py — TeXML builder (no Odoo model)
 
 `VoiceResponse`, `Gather`, `Dial` (+`sip()`/`number()`/`conference()`),
@@ -249,6 +262,9 @@ validation: Ed25519 over the raw body
 | `/telnyx/webhook/callaction` | Generic call action |
 | `/telnyx/webhook/texml/<id>` | TeXML app voice request |
 | `/telnyx/webhook/message` | Messaging v2 JSON events |
+| `/telnyx/webhook/assistant/<id>/variables` | Signed caller context and memory configuration |
+| `/telnyx/webhook/assistant/<id>/tool/<name>` | Token-authenticated allowlisted Odoo tool |
+| `/telnyx/webhook/assistant/insights` | Signed conversation summary delivery |
 
 ---
 

--- a/specs/decisions/034-connect-telnyx-ai-assistants.md
+++ b/specs/decisions/034-connect-telnyx-ai-assistants.md
@@ -1,0 +1,34 @@
+# 034: Telnyx AI Assistants remain behind the Odoo TeXML router
+
+## Context
+
+Telnyx can assign a number directly to an AI Assistant, but `connect_telnyx`
+already attaches every number to one routing TeXML application. Direct
+assignment would bypass the provider's destination selection, call ledger,
+partner matching, webhook verification and coexistence with users/callflows.
+
+## Decision
+
+1. AI Assistants are managed as `connect.telnyx.ai_assistant` records. Odoo
+   creates, updates, imports and deletes the corresponding `/v2/ai/assistants`
+   resources.
+2. A number with destination `ai_assistant` stays attached to the existing
+   routing TeXML application. Its render result is
+   `<Connect><AIAssistant id="…"/></Connect>`.
+3. Caller context is supplied by a signed dynamic-variables webhook. Mutable
+   Odoo operations use per-assistant random tool tokens and a fixed allowlist;
+   arbitrary model access and server actions are not exposed.
+4. Voice conversations are synchronized into `connect.call` and a
+   `connect.recording` record with `source=telnyx-ai`. Transcript and native
+   Telnyx summary are idempotently refreshed by webhook plus cron fallback.
+5. Recording and cross-conversation memory are opt-in. Telephony is enabled;
+   assistant messaging is outside this change.
+
+## Consequences
+
+- Existing Telnyx destinations and call accounting remain compatible.
+- Odoo's public URL and Ed25519 public key must be configured before assistant
+  synchronization.
+- CRM and Helpdesk tools appear only when their companion modules are installed.
+- Inline webhook tools are limited to per-assistant Odoo endpoints whose token
+  cannot be shared safely in the global Telnyx tool library.


### PR DESCRIPTION
Adds managed Telnyx AI Assistants, including Odoo records, admin views, ACLs, sync/import behavior, per-assistant webhook tools, dynamic variables, and summary insight synchronization. Routes AI assistant numbers through the existing TeXML router and adds an outbound Call with Assistant wizard using the TeXML AI call endpoint. Stores AI conversations as call-linked recordings with transcript and summary data, plus cron/webhook fallback synchronization. Includes setup documentation, ADR/spec updates, and mocked unit coverage for assistant sync, tools, routing, conversation import, auto-sync behavior, and outbound AI call endpoint selection.