### PR TITLE
Docs: SIP trunk password rotation runbook

### DIFF
--- a/docs/admin/freeswitch-setup.md
+++ b/docs/admin/freeswitch-setup.md
@@ -407,6 +407,62 @@ The following profile-level parameters handle NAT transparently:
 
 No per-user configuration is needed — NAT handling applies automatically to all registrations on the external profile.
 
+## Operations Runbook
+
+### Rotate the SIP trunk password
+
+Use this procedure when the SIP provider forces a credential rotation or
+as routine security hygiene. The mechanics are simple: saving a new
+password on the gateway record automatically restarts the sofia
+`external` profile, FreeSWITCH re-reads the gateway XML through
+xml_curl and re-registers within a few seconds.
+
+**Coordination.** If the provider portal requires setting the new
+password manually, agree on the order with the provider first: set the
+new password on the provider side, then in Odoo. Between the two steps
+outbound registration fails with `FAIL_WAIT`, so keep the window short.
+The expected registration gap after the Odoo save is a few seconds.
+
+**Steps:**
+
+1. Obtain (or generate and set) the new trunk password in the
+   provider's portal.
+2. In Odoo open **Connect → FreeSWITCH → Gateways**, open the trunk
+   gateway and paste the new value into **Password** (the field is
+   visible to Connect admins only), then **Save**. The save schedules a
+   post-commit `sofia profile external restart reloadxml`, so the new
+   credentials are picked up without touching the container.
+
+   The same change over the API (e.g. from an Odoo shell):
+
+   ```python
+   env['connect.freeswitch.gateway'].search(
+       [('name', '=', 'mytrunk')]).write({'password': 'NEW-SECRET'})
+   ```
+
+**Verification:**
+
+1. Check the registration state — `State` must be `REGED`:
+
+   ```
+   fs_cli -x "sofia status gateway mytrunk"
+   ```
+
+2. Smoke test: one outbound call through the trunk and one inbound call
+   to a DID.
+
+**Recovery (wrong password):**
+
+- `sofia status gateway <name>` shows `FAIL_WAIT` / `TRYING` instead of
+  `REGED` and the provider rejects REGISTER with 401/403. Revert by
+  writing the previous password back on the gateway record (same flow,
+  the profile restarts again).
+- If the profile looks stuck, force the reload manually:
+
+  ```
+  fs_cli -x "sofia profile external restart reloadxml"
+  ```
+
 ## Troubleshooting
 
 ### Incoming calls not reaching SIP phone


### PR DESCRIPTION
Fixes #51.

Adds an **Operations Runbook** section to `docs/admin/freeswitch-setup.md` with the "Rotate the SIP trunk password" procedure:

- update the gateway **Password** in Odoo (UI or `connect.freeswitch.gateway.write({'password': ...})`) — the save schedules a post-commit `sofia profile external restart reloadxml`, so FreeSWITCH re-reads the gateway XML via xml_curl and re-registers within seconds;
- verification via `fs_cli -x "sofia status gateway <name>"` (expect `REGED`) plus an outbound/inbound smoke test;
- recovery from a wrong password (revert via the same write; manual profile reload as a fallback);
- coordination notes for providers whose portal needs a manual update first.

Docs-only change — no manifest bump, page already in the mkdocs nav.